### PR TITLE
Add fractal demo page with spinning canvas

### DIFF
--- a/fractal.html
+++ b/fractal.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Fractal Demo</title>
+  <style>
+    body { margin: 0; overflow-x: hidden; background: #000; color: #fff; font-family: sans-serif; }
+    canvas { display: block; }
+    .spin { position: fixed; top: 1rem; right: 1rem; width: 50px; height: 50px; border-radius: 50%; border: 4px solid #fff; border-top-color: transparent; animation: spin 2s linear infinite; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    section { height: 100vh; display: flex; align-items: center; justify-content: center; font-size: 2rem; }
+    .hidden { opacity: 0; transform: translateY(20px); transition: opacity .6s, transform .6s; }
+    .show { opacity: 1; transform: none; }
+  </style>
+</head>
+<body>
+  <div class="spin"></div>
+  <canvas id="fractal"></canvas>
+  <section style="background:#111;" class="show">Scroll down for more ✨</section>
+  <section style="background:#222;" class="hidden">You found the ancient geometry!</section>
+  <script>
+    const canvas = document.getElementById('fractal');
+    const ctx = canvas.getContext('2d');
+    function resize() {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+      draw();
+    }
+    window.addEventListener('resize', resize);
+    resize();
+    function drawFractal(x, y, size) {
+      if (size < 2) return;
+      ctx.strokeRect(x, y, size, size);
+      const s = size / 2;
+      drawFractal(x, y, s);
+      drawFractal(x + s, y, s);
+      drawFractal(x, y + s, s);
+      drawFractal(x + s, y + s, s);
+    }
+    function draw() {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.strokeStyle = '#0ff';
+      drawFractal(0, 0, Math.min(canvas.width, canvas.height));
+    }
+    // Scroll reveal
+    const obs = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) entry.target.classList.add('show');
+      });
+    });
+    document.querySelectorAll('section.hidden').forEach(sec => obs.observe(sec));
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -69,6 +69,16 @@
               <div class="text-xl">↗</div>
             </div>
           </a>
+            <a class="block w-full rounded-2xl border border-slate-300 dark:border-slate-700 px-5 py-4 hover:bg-slate-100 dark:hover:bg-slate-800 transition" href="/fractal.html">
+              <div class="flex items-center justify-between">
+                <div>
+                  <div class="font-semibold">Fractal Demo</div>
+                  <div class="text-sm opacity-70">Canvas fractal with scroll</div>
+                </div>
+                <div class="text-xl">🌀</div>
+              </div>
+            </a>
+
 
           <a class="block w-full rounded-2xl border border-slate-300 dark:border-slate-700 px-5 py-4 hover:bg-slate-100 dark:hover:bg-slate-800 transition" href="#farm">
             <div class="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- Add `fractal.html` showcasing a recursive canvas fractal, spinning element, and scroll reveal
- Link to the new fractal demo from the main index page

## Testing
- `npm test` (fails: missing package.json, no tests defined)


------
https://chatgpt.com/codex/tasks/task_e_68c831a225d08330bf24b2ea46fd3193