### PR TITLE
Enhance contact experience and refresh project statuses

### DIFF
--- a/contact-form.html
+++ b/contact-form.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Detailed Intake Form — IsaacInPursuit</title>
+  <meta name="description" content="Share context via Google Form before we connect." />
+  <meta property="og:title" content="Detailed Intake Form — IsaacInPursuit" />
+  <meta property="og:description" content="A Google Form intake for project and collaboration requests." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://isaacinpursuit.github.io/contact-form.html" />
+  <meta property="og:image" content="/og.png" />
+  <meta property="og:site_name" content="IsaacInPursuit" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Detailed Intake Form — IsaacInPursuit" />
+  <meta name="twitter:description" content="Provide background before we meet using the Google Form." />
+  <meta name="twitter:image" content="https://isaacinpursuit.github.io/og.png" />
+  <meta name="author" content="Isaac Johnston" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='0.9em' font-size='90'%3E%F0%9F%8C%8A%3C/text%3E%3C/svg%3E" />
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+  <!-- Tailwind (CDN) -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { darkMode: 'class', theme: { extend: {
+      fontFamily: { sans: ['Inter','system-ui','sans-serif'] },
+      colors: { brand: { 500:'#06b6d4',600:'#0891b2',700:'#0e7490' } },
+      boxShadow: { soft: '0 12px 32px rgba(2,6,23,.18)' }
+    }}};
+  </script>
+</head>
+<body class="bg-slate-50 text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100">
+  <main class="min-h-screen py-12 px-4">
+    <div class="mx-auto flex w-full max-w-4xl flex-col gap-6">
+      <header class="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-200/80 bg-white/80 px-5 py-4 shadow-soft dark:border-slate-800/70 dark:bg-slate-900/60">
+        <a href="/links.html" class="inline-flex items-center gap-2 text-sm font-semibold text-brand-600 transition hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200">← Back to links</a>
+        <button id="themeToggle" class="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:text-slate-200 dark:hover:border-brand-400 dark:hover:text-brand-200">🌗 Theme</button>
+      </header>
+      <div class="rounded-3xl border border-slate-200/80 bg-white/80 shadow-soft dark:border-slate-800/70 dark:bg-slate-900/60">
+        <div class="space-y-4 border-b border-slate-200/70 p-6 dark:border-slate-800/70 md:p-10">
+          <h1 class="text-3xl font-bold text-slate-900 dark:text-white">Detailed intake form</h1>
+          <p class="text-sm text-slate-600 dark:text-slate-300">Share context around your project, partnership idea, or hiring need. Responses land in the same inbox as the quick message form, just with more prompts to guide our first conversation.</p>
+          <div class="flex flex-wrap gap-3 text-sm">
+            <a href="/index.html#contact" class="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:text-slate-200 dark:hover:border-brand-400 dark:hover:text-brand-200">⬅ Back to contact</a>
+            <a href="mailto:isaacinpursuit@gmail.com" class="inline-flex items-center gap-2 rounded-full bg-brand-600 px-4 py-2 font-semibold text-white shadow-soft transition hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500">✉️ Email instead</a>
+          </div>
+        </div>
+        <div class="space-y-3 p-6 md:p-10">
+          <div class="overflow-hidden rounded-2xl border border-slate-200 bg-white/90 shadow-inner dark:border-slate-800 dark:bg-slate-900/40">
+            <iframe title="Google intake form" src="https://forms.gle/QEEHH4ic7yET2B9p9" loading="lazy" class="h-[720px] w-full" allowfullscreen></iframe>
+          </div>
+          <p class="text-sm text-slate-600 dark:text-slate-300">If the Google Form doesn’t display inside this page, <a class="font-medium text-brand-600 hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200" href="https://forms.gle/QEEHH4ic7yET2B9p9" target="_blank" rel="noopener">open it in a new tab</a>.</p>
+        </div>
+      </div>
+      <footer class="text-center text-xs text-slate-500 dark:text-slate-400">© <span id="year"></span> Isaac Johnston.</footer>
+    </div>
+  </main>
+
+  <script>
+    const applyTheme = () => {
+      if (localStorage.theme === 'dark' || (!('theme' in localStorage) && matchMedia('(prefers-color-scheme: dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+      }
+    };
+    applyTheme();
+    document.getElementById('themeToggle')?.addEventListener('click', () => {
+      const isDark = document.documentElement.classList.toggle('dark');
+      localStorage.theme = isDark ? 'dark' : 'light';
+    });
+
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/fractal.html
+++ b/fractal.html
@@ -2,7 +2,19 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Golden Fractal</title>
+  <title>Golden Fractal — IsaacInPursuit</title>
+  <meta name="description" content="Scroll to grow a golden-ratio fractal demo built by Isaac Johnston." />
+  <meta property="og:title" content="Golden Fractal — IsaacInPursuit" />
+  <meta property="og:description" content="Interactive fractal visualization that expands as you scroll." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://isaacinpursuit.github.io/fractal.html" />
+  <meta property="og:image" content="/og.png" />
+  <meta property="og:site_name" content="IsaacInPursuit" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Golden Fractal — IsaacInPursuit" />
+  <meta name="twitter:description" content="Interactive fractal visualization that expands as you scroll." />
+  <meta name="twitter:image" content="https://isaacinpursuit.github.io/og.png" />
+  <meta name="author" content="Isaac Johnston" />
   <style>
     body {margin:0; overflow-x:hidden; background:#000; color:#fff; font-family:sans-serif;}
     canvas {position:fixed; top:0; left:0; display:block; z-index:-1;}
@@ -14,8 +26,8 @@
   </style>
 </head>
 <body>
-  <div class="spin"></div>
-  <canvas id="fractal"></canvas>
+  <div class="spin" aria-hidden="true"></div>
+  <canvas id="fractal" aria-hidden="true"></canvas>
   <section class="show" style="background:#111;">Scroll to grow the golden fractal 🍃</section>
   <section class="hidden" style="background:#222;">Math: φ = (1+√5)/2 rules the lengths.</section>
   <section class="hidden" style="background:#333;">History: Egyptians, Greeks and da Vinci sought this harmony.</section>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,12 @@
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://isaacinpursuit.github.io/" />
   <meta property="og:image" content="/og.png" />
+  <meta property="og:site_name" content="IsaacInPursuit" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Isaac Johnston" />
+  <meta name="twitter:description" content="Entrepreneur partnering with operators to launch resilient ventures." />
+  <meta name="twitter:image" content="https://isaacinpursuit.github.io/og.png" />
+  <meta name="author" content="Isaac Johnston" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='0.9em' font-size='90'%3E%F0%9F%8C%8A%3C/text%3E%3C/svg%3E" />
 
   <!-- Fonts -->
@@ -75,7 +81,7 @@
           <h1 class="text-4xl font-extrabold leading-tight text-slate-900 dark:text-white md:text-5xl">Faith-led builder helping operators launch resilient ventures.</h1>
           <p class="text-lg text-slate-600 dark:text-slate-300">I partner with founders, property leaders, and community builders to move from idea to traction. My approach blends capital strategy, product experimentation, and operational rigor — always rooted in faith and integrity.</p>
           <div class="flex flex-wrap gap-3">
-            <a href="https://calendly.com/isaacinpursuit/15min" class="inline-flex items-center gap-2 rounded-full bg-brand-600 px-5 py-2.5 text-sm font-semibold text-white shadow-soft transition hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500">Book a 15‑min call</a>
+            <a href="https://calendar.app.google/V6WfbjRRDxbFr6X69" class="inline-flex items-center gap-2 rounded-full bg-brand-600 px-5 py-2.5 text-sm font-semibold text-white shadow-soft transition hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500">Book a 15‑min call</a>
             <a href="/resume.pdf" class="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white/70 px-5 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:bg-slate-950/40 dark:text-slate-200 dark:hover:border-brand-400 dark:hover:text-brand-200">Download resume</a>
             <a href="#projects" class="inline-flex items-center gap-2 rounded-full border border-transparent bg-slate-900/90 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-900 dark:bg-white/10 dark:text-white dark:hover:bg-white/20">View recent wins</a>
           </div>
@@ -100,18 +106,19 @@
               <span class="inline-flex items-center gap-2 rounded-full bg-brand-500/15 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-brand-700 dark:text-brand-200"><span aria-hidden="true">⚡️</span> Current focus</span>
               <span class="text-xs text-slate-500 dark:text-slate-400">Updated weekly</span>
             </div>
+            <p class="mt-4 text-sm text-slate-600 dark:text-slate-300">These are the hands-on sprints I’m running inside the initiatives detailed in the Projects section below — consider them the in-flight tasks powering each venture’s status.</p>
             <ul class="mt-6 space-y-4 text-sm text-slate-600 dark:text-slate-300">
               <li class="flex gap-3">
                 <span class="mt-1 text-brand-600">▹</span>
-                <span><strong>Farm Compliance MVP:</strong> rolling out multilingual onboarding flows and audit-ready checklists for southeastern growers.</span>
+                <span><strong>Farm Compliance MVP (in development):</strong> rolling out multilingual onboarding flows and audit-ready checklists for southeastern growers.</span>
               </li>
               <li class="flex gap-3">
                 <span class="mt-1 text-brand-600">▹</span>
-                <span><strong>UNCC Student Network:</strong> expanding a talent marketplace that connects students with operators and recruiters.</span>
+                <span><strong>UNCC Student Network (active):</strong> expanding a talent marketplace that connects students with operators and recruiters.</span>
               </li>
               <li class="flex gap-3">
                 <span class="mt-1 text-brand-600">▹</span>
-                <span><strong>Cali Baking MVP:</strong> testing new product drops and local delivery partnerships for a growing food brand.</span>
+                <span><strong>Cali Baking MVP (in development):</strong> testing new product drops and local delivery partnerships for a growing food brand.</span>
               </li>
             </ul>
             <div class="mt-8 rounded-2xl border border-dashed border-brand-500/40 bg-brand-500/5 p-5 text-sm text-slate-600 dark:border-brand-500/30 dark:text-slate-200">
@@ -166,6 +173,7 @@
         <div>
           <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600 dark:text-brand-300">Projects</p>
           <h2 class="text-3xl font-bold text-slate-900 dark:text-white">Building with operators in the field</h2>
+          <p class="mt-2 max-w-2xl text-sm text-slate-600 dark:text-slate-300">Status badges reflect where each initiative sits today, complementing the “Current focus” sprints above so you can see both the week-to-week work and the broader milestone.</p>
         </div>
         <a href="mailto:isaacinpursuit@gmail.com" class="inline-flex items-center gap-2 text-sm font-semibold text-brand-600 transition hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200">Share an opportunity →</a>
       </div>
@@ -173,9 +181,9 @@
         <article class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-800/70 dark:bg-slate-950/60">
           <div class="flex items-center justify-between gap-4">
             <h3 class="text-xl font-semibold text-slate-900 dark:text-white">Farm Compliance MVP</h3>
-            <span class="rounded-full bg-brand-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-brand-700 dark:bg-brand-500/20 dark:text-brand-200">Active</span>
+            <span class="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:bg-amber-500/20 dark:text-amber-100">In development</span>
           </div>
-          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">A multilingual onboarding and audit preparation toolkit that keeps growers aligned with labor, safety, and food-handling standards.</p>
+          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">A multilingual onboarding and audit preparation toolkit in build-mode to keep growers aligned with labor, safety, and food-handling standards before the public beta.</p>
           <ul class="mt-4 space-y-2 text-sm text-slate-600 dark:text-slate-300">
             <li class="flex gap-2"><span class="text-brand-600">•</span> Implemented mobile-first checklists with offline sync for in-field teams.</li>
             <li class="flex gap-2"><span class="text-brand-600">•</span> Partnering with agronomists to co-create compliance education modules.</li>
@@ -184,9 +192,9 @@
         <article class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-800/70 dark:bg-slate-950/60">
           <div class="flex items-center justify-between gap-4">
             <h3 class="text-xl font-semibold text-slate-900 dark:text-white">UNCC Student Network</h3>
-            <span class="rounded-full bg-slate-900/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700 dark:bg-white/10 dark:text-white">Pilot</span>
+            <span class="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-100">Active</span>
           </div>
-          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Community-driven recruiting that connects students with startups, growth-stage companies, and civic projects across Charlotte.</p>
+          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Community-driven recruiting that connects students with startups, growth-stage companies, and civic projects across Charlotte. Currently running meetups and matching talent with operator roles.</p>
           <ul class="mt-4 space-y-2 text-sm text-slate-600 dark:text-slate-300">
             <li class="flex gap-2"><span class="text-brand-600">•</span> Launching micro-events and office hours to surface talent.</li>
             <li class="flex gap-2"><span class="text-brand-600">•</span> Coordinating hiring pipelines for internships and operator residencies.</li>
@@ -195,9 +203,9 @@
         <article class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-800/70 dark:bg-slate-950/60">
           <div class="flex items-center justify-between gap-4">
             <h3 class="text-xl font-semibold text-slate-900 dark:text-white">Cali Baking MVP</h3>
-            <span class="rounded-full bg-slate-900/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700 dark:bg-white/10 dark:text-white">Launch</span>
+            <span class="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:bg-amber-500/20 dark:text-amber-100">In development</span>
           </div>
-          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Experiments in e-commerce, delivery, and subscription models that scale a beloved local bakery beyond brick-and-mortar.</p>
+          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Experiments in e-commerce, delivery, and subscription models that scale a beloved local bakery beyond brick-and-mortar — still validating before a public launch.</p>
           <ul class="mt-4 space-y-2 text-sm text-slate-600 dark:text-slate-300">
             <li class="flex gap-2"><span class="text-brand-600">•</span> Built drop schedules and SMS waitlists to drive limited releases.</li>
             <li class="flex gap-2"><span class="text-brand-600">•</span> Testing partnerships with coffee shops and community markets.</li>
@@ -252,13 +260,13 @@
           <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">One-page overview of roles, projects, and impact.</p>
           <p class="mt-4 text-sm font-semibold text-brand-600 dark:text-brand-300">Download PDF →</p>
         </a>
-        <a class="group rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-800/70 dark:bg-slate-950/60" href="https://calendly.com/isaacinpursuit/15min">
+        <a class="group rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-800/70 dark:bg-slate-950/60" href="https://calendar.app.google/V6WfbjRRDxbFr6X69">
           <div class="flex items-center justify-between">
             <div class="text-lg font-semibold text-slate-900 dark:text-white">Book time</div>
             <span class="text-xl">🗓️</span>
           </div>
           <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">15-minute intro chats to explore partnerships or brainstorm ideas.</p>
-          <p class="mt-4 text-sm font-semibold text-brand-600 dark:text-brand-300">Open calendar →</p>
+          <p class="mt-4 text-sm font-semibold text-brand-600 dark:text-brand-300">Book via Google Calendar →</p>
         </a>
         <a class="group rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-800/70 dark:bg-slate-950/60" href="mailto:isaacinpursuit@gmail.com">
           <div class="flex items-center justify-between">
@@ -313,7 +321,7 @@
         <p class="mx-auto max-w-2xl text-base text-slate-600 dark:text-slate-300">Share what you’re building, where you’re feeling stuck, or how we might co-create impact. I read every message.</p>
       </div>
       <div class="grid gap-10 md:grid-cols-2 md:items-start">
-        <form action="https://formspree.io/f/your-id" method="POST" class="space-y-5 rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft dark:border-slate-800/70 dark:bg-slate-950/60">
+        <form action="https://formspree.io/f/mkgnjopd" method="POST" data-form class="space-y-5 rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft dark:border-slate-800/70 dark:bg-slate-950/60">
           <div class="space-y-2">
             <label class="block text-sm font-semibold text-slate-700 dark:text-slate-200" for="name">Name</label>
             <input required id="name" type="text" name="name" placeholder="Your name" class="w-full rounded-2xl border border-slate-300 bg-white/90 px-4 py-3 text-sm text-slate-900 transition focus:border-brand-500 focus:outline-none dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100" />
@@ -328,7 +336,8 @@
           </div>
           <div class="space-y-3">
             <button class="w-full rounded-2xl bg-brand-600 px-4 py-3 text-sm font-semibold text-white shadow-soft transition hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500">Send message</button>
-            <p class="text-xs text-slate-500 dark:text-slate-400">Powered by Formspree. I’ll reply within two business days.</p>
+            <p class="text-xs text-slate-500 dark:text-slate-400">Powered by Formspree. Prefer email? <a class="font-medium text-brand-600 hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200" href="mailto:isaacinpursuit@gmail.com">isaacinpursuit@gmail.com</a>.</p>
+            <p data-form-status role="status" aria-live="polite" class="hidden text-sm font-medium text-brand-600 dark:text-brand-300"></p>
           </div>
         </form>
         <div class="space-y-6">
@@ -336,15 +345,28 @@
             <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Prefer a direct line?</h3>
             <ul class="mt-4 space-y-3 text-sm text-slate-600 dark:text-slate-300">
               <li><a class="inline-flex items-center gap-2 text-brand-600 transition hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200" href="mailto:isaacinpursuit@gmail.com"><span aria-hidden="true">✉️</span> isaacinpursuit@gmail.com</a></li>
-              <li><a class="inline-flex items-center gap-2 text-brand-600 transition hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200" href="https://calendly.com/isaacinpursuit/15min"><span aria-hidden="true">🗓️</span> Book intro call</a></li>
+              <li><a class="inline-flex items-center gap-2 text-brand-600 transition hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200" href="https://calendar.app.google/V6WfbjRRDxbFr6X69"><span aria-hidden="true">🗓️</span> Book intro call</a></li>
               <li><a class="inline-flex items-center gap-2 text-brand-600 transition hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200" href="https://www.linkedin.com/in/isaacinpursuit/"><span aria-hidden="true">💼</span> LinkedIn updates</a></li>
             </ul>
+          </div>
+          <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft dark:border-slate-800/70 dark:bg-slate-950/60">
+            <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Book a meeting</h3>
+            <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Reserve a 15-minute slot on my Google appointment schedule for quick intros or project scoping.</p>
+            <a href="https://calendar.app.google/V6WfbjRRDxbFr6X69" class="mt-4 inline-flex items-center justify-center gap-2 rounded-2xl bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white shadow-soft transition hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500">Book via Google Calendar</a>
           </div>
           <div class="rounded-3xl border border-dashed border-brand-500/40 bg-brand-500/5 p-6 text-sm text-slate-600 dark:border-brand-500/30 dark:text-slate-200">
             <p class="font-semibold text-brand-700 dark:text-brand-200">Looking for a collaborator?</p>
             <p class="mt-2">Bring me in to evaluate a deal, run a sprint, or mentor a team. I’ll map the path to traction with you.</p>
           </div>
         </div>
+      </div>
+      <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft dark:border-slate-800/70 dark:bg-slate-950/60">
+        <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Alternate intake form</h3>
+        <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Prefer a structured questionnaire? Submit the Google Form below — it routes to the same inbox and helps me prep before we connect.</p>
+        <div class="mt-5 overflow-hidden rounded-2xl border border-slate-200 bg-white/90 shadow-inner dark:border-slate-800 dark:bg-slate-900/40">
+          <iframe title="Google intake form" src="https://forms.gle/QEEHH4ic7yET2B9p9" loading="lazy" class="h-[640px] w-full" allowfullscreen></iframe>
+        </div>
+        <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">If the form doesn’t load, <a class="font-medium text-brand-600 hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200" href="https://forms.gle/QEEHH4ic7yET2B9p9" target="_blank" rel="noopener">open it in a new tab</a>.</p>
       </div>
     </section>
   </main>
@@ -387,6 +409,56 @@
     };
     toggleHeaderState();
     window.addEventListener('scroll', toggleHeaderState, { passive: true });
+
+    // Form submission handling
+    const successClasses = ['text-brand-600', 'dark:text-brand-300'];
+    const errorClasses = ['text-red-600', 'dark:text-red-400'];
+    document.querySelectorAll('form[data-form]').forEach(form => {
+      const statusEl = form.querySelector('[data-form-status]');
+      const submitButton = form.querySelector('button[type="submit"]');
+      if (!statusEl) return;
+
+      form.addEventListener('submit', async event => {
+        event.preventDefault();
+        statusEl.classList.remove('hidden');
+        statusEl.textContent = 'Sending…';
+        statusEl.classList.remove(...errorClasses);
+        statusEl.classList.add(...successClasses);
+        if (submitButton) {
+          submitButton.disabled = true;
+          submitButton.setAttribute('aria-disabled', 'true');
+        }
+
+        try {
+          const formData = new FormData(form);
+          const response = await fetch(form.action, {
+            method: 'POST',
+            body: formData,
+            headers: { Accept: 'application/json' },
+          });
+
+          if (response.ok) {
+            statusEl.textContent = 'Thanks! Your message is on its way.';
+            form.reset();
+          } else {
+            const data = await response.json().catch(() => null);
+            const message = data?.errors?.[0]?.message || data?.message || 'Something went wrong. Please email isaacinpursuit@gmail.com.';
+            statusEl.textContent = message;
+            statusEl.classList.remove(...successClasses);
+            statusEl.classList.add(...errorClasses);
+          }
+        } catch (error) {
+          statusEl.textContent = 'Something went wrong. Please email isaacinpursuit@gmail.com.';
+          statusEl.classList.remove(...successClasses);
+          statusEl.classList.add(...errorClasses);
+        } finally {
+          if (submitButton) {
+            submitButton.disabled = false;
+            submitButton.removeAttribute('aria-disabled');
+          }
+        }
+      });
+    });
 
     // Year stamp
     document.getElementById('year').textContent = new Date().getFullYear();

--- a/links.html
+++ b/links.html
@@ -10,6 +10,12 @@
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://isaacinpursuit.github.io/" />
   <meta property="og:image" content="/og.png" />
+  <meta property="og:site_name" content="IsaacInPursuit" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="IsaacInPursuit — Links" />
+  <meta name="twitter:description" content="Projects, socials, contact, resume — on a fast, self-hosted hub." />
+  <meta name="twitter:image" content="https://isaacinpursuit.github.io/og.png" />
+  <meta name="author" content="Isaac Johnston" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='0.9em' font-size='90'%3E%F0%9F%8C%8A%3C/text%3E%3C/svg%3E" />
 
   <!-- Fonts -->
@@ -69,6 +75,15 @@
               <div class="text-xl">↗</div>
             </div>
           </a>
+          <a class="block w-full rounded-2xl border border-slate-300 dark:border-slate-700 px-5 py-4 hover:bg-slate-100 dark:hover:bg-slate-800 transition" href="https://calendar.app.google/V6WfbjRRDxbFr6X69">
+            <div class="flex items-center justify-between">
+              <div>
+                <div class="font-semibold">Book a 15-min intro</div>
+                <div class="text-sm opacity-70">Reserve via Google Calendar</div>
+              </div>
+              <div class="text-xl">🗓️</div>
+            </div>
+          </a>
             <a class="block w-full rounded-2xl border border-slate-300 dark:border-slate-700 px-5 py-4 hover:bg-slate-100 dark:hover:bg-slate-800 transition" href="/fractal.html">
               <div class="flex items-center justify-between">
                 <div>
@@ -120,18 +135,28 @@
               <div class="text-xl">✉️</div>
             </div>
           </a>
+          <a class="block w-full rounded-2xl border border-slate-300 dark:border-slate-700 px-5 py-4 hover:bg-slate-100 dark:hover:bg-slate-800 transition" href="/contact-form.html">
+            <div class="flex items-center justify-between">
+              <div>
+                <div class="font-semibold">Detailed Intake Form</div>
+                <div class="text-sm opacity-70">Google Form questionnaire</div>
+              </div>
+              <div class="text-xl">📝</div>
+            </div>
+          </a>
         </div>
 
         <!-- Contact form -->
         <div id="contact" class="px-8 pb-8">
-          <form action="https://formspree.io/f/your-id" method="POST" class="space-y-3">
+          <form action="https://formspree.io/f/mkgnjopd" method="POST" data-form class="space-y-3">
             <div class="text-sm font-semibold">Quick message</div>
             <input required type="text" name="name" placeholder="Your name" class="w-full px-4 py-3 rounded-xl border border-slate-300 dark:border-slate-700 bg-transparent" />
             <input required type="email" name="email" placeholder="you@example.com" class="w-full px-4 py-3 rounded-xl border border-slate-300 dark:border-slate-700 bg-transparent" />
             <textarea required name="message" rows="4" placeholder="What's up?" class="w-full px-4 py-3 rounded-xl border border-slate-300 dark:border-slate-700 bg-transparent"></textarea>
-            <button class="w-full px-4 py-3 rounded-xl bg-brand-600 text-white hover:bg-brand-700">Send</button>
+            <button type="submit" class="w-full px-4 py-3 rounded-xl bg-brand-600 text-white shadow-soft transition hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500">Send</button>
+            <p data-form-status role="status" aria-live="polite" class="hidden text-sm font-medium text-brand-600 dark:text-brand-300"></p>
           </form>
-          <p class="mt-2 text-xs text-slate-500">Replace Formspree endpoint with your own or wire to a serverless function later.</p>
+          <p class="mt-2 text-xs text-slate-500 dark:text-slate-400">Powered by Formspree. Need more space? Try the <a class="font-medium text-brand-600 hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200" href="/contact-form.html">detailed intake form</a>.</p>
         </div>
       </div>
 
@@ -155,6 +180,56 @@
       const isDark = document.documentElement.classList.toggle('dark');
       localStorage.theme = isDark ? 'dark' : 'light';
     })
+
+    // Form submission handling
+    const successClasses = ['text-brand-600', 'dark:text-brand-300'];
+    const errorClasses = ['text-red-600', 'dark:text-red-400'];
+    document.querySelectorAll('form[data-form]').forEach(form => {
+      const statusEl = form.querySelector('[data-form-status]');
+      const submitButton = form.querySelector('button[type="submit"]');
+      if (!statusEl) return;
+
+      form.addEventListener('submit', async event => {
+        event.preventDefault();
+        statusEl.classList.remove('hidden');
+        statusEl.textContent = 'Sending…';
+        statusEl.classList.remove(...errorClasses);
+        statusEl.classList.add(...successClasses);
+        if (submitButton) {
+          submitButton.disabled = true;
+          submitButton.setAttribute('aria-disabled', 'true');
+        }
+
+        try {
+          const formData = new FormData(form);
+          const response = await fetch(form.action, {
+            method: 'POST',
+            body: formData,
+            headers: { Accept: 'application/json' }
+          });
+
+          if (response.ok) {
+            statusEl.textContent = 'Thanks! Your message is on its way.';
+            form.reset();
+          } else {
+            const data = await response.json().catch(() => null);
+            const message = data?.errors?.[0]?.message || data?.message || 'Something went wrong. Email isaacinpursuit@gmail.com.';
+            statusEl.textContent = message;
+            statusEl.classList.remove(...successClasses);
+            statusEl.classList.add(...errorClasses);
+          }
+        } catch (error) {
+          statusEl.textContent = 'Something went wrong. Email isaacinpursuit@gmail.com.';
+          statusEl.classList.remove(...successClasses);
+          statusEl.classList.add(...errorClasses);
+        } finally {
+          if (submitButton) {
+            submitButton.disabled = false;
+            submitButton.removeAttribute('aria-disabled');
+          }
+        }
+      });
+    });
 
     // Year stamp
     document.getElementById('year').textContent = new Date().getFullYear();


### PR DESCRIPTION
## Summary
- replace placeholder Formspree endpoints with the active submission URL and add inline success/error handling for the contact forms
- add a dedicated meeting CTA, embed the Google intake form (with fallback link), and publish a standalone contact-form.html page for longer submissions
- refresh project badges/copy to reflect current statuses and update SEO metadata across pages (including the fractal demo)

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8a69c7af083308555ee0a8f80199e