### PR TITLE
Add math visualization gallery with interactive demos

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1091 +1,300 @@
-<!doctype html>
-<html lang="en" class="scroll-smooth">
+<!DOCTYPE html>
+<html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Isaac Johnston</title>
-  <meta name="description" content="Entrepreneur in real estate, finance, and startups." />
-  <meta property="og:title" content="Isaac Johnston" />
-  <meta property="og:description" content="Grounded in service. Focused on growth. Open to learning." />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://isaacinpursuit.github.io/" />
-  <meta property="og:image" content="/og.png" />
-  <meta property="og:site_name" content="IsaacInPursuit" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Isaac Johnston" />
-  <meta name="twitter:description" content="Entrepreneur partnering with operators to launch resilient ventures." />
-  <meta name="twitter:image" content="https://isaacinpursuit.github.io/og.png" />
-  <meta name="author" content="Isaac Johnston" />
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='0.9em' font-size='90'%3E%F0%9F%8C%8A%3C/text%3E%3C/svg%3E" />
-
-  <!-- Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-
-  <!-- Tailwind (CDN) -->
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = { darkMode: 'class', theme: { extend: {
-      fontFamily: { sans: ['Inter','system-ui','sans-serif'] },
-      colors: { brand: { 500:'#06b6d4',600:'#0891b2',700:'#0e7490' } },
-      boxShadow: { soft: '0 12px 32px rgba(2,6,23,.18)' }
-    }}}
-  </script>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mathematical Demo Garden</title>
+  <meta name="description" content="A gallery of mathematical and geometric demonstrations rendered in realtime on the web." />
   <style>
-    .fade-in { animation: fadeIn .6s ease both }
-    @keyframes fadeIn { from{opacity:0;transform:translateY(10px)} to{opacity:1;transform:none} }
-    .floating { animation: float 14s ease-in-out infinite alternate }
-    @keyframes float { from{transform:translateY(-8px) scale(1)} to{transform:translateY(8px) scale(1.05)} }
-    @media (prefers-reduced-motion: reduce) {
-      .fade-in, .floating { animation-duration: 0.01ms; animation-iteration-count: 1 }
+    :root {
+      color-scheme: dark light;
+      --bg: #05060a;
+      --bg-panel: rgba(8, 10, 18, 0.85);
+      --fg: #f4f6ff;
+      --accent: #f7b733;
+      --accent-strong: #fc4a1a;
+      --border: rgba(255, 255, 255, 0.15);
+      --shadow: rgba(0, 0, 0, 0.25);
+      font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
     }
-    :root { --fract-bg:#0b1120; --fract-fg:#e0f2fe }
-    .dark { --fract-bg:#020617; --fract-fg:#f8fafc }
-    #fractalOverlay {
-      position: fixed;
-      left: 0;
-      right: 0;
-      top: clamp(5.5rem, 8vw, 8.5rem);
-      display: flex;
-      justify-content: center;
-      padding: 0 1.5rem;
-      pointer-events: none;
-      z-index: 20;
-      opacity: 0;
-      transform: translateY(0);
-      transition: opacity .3s ease, transform .45s ease;
-      will-change: transform, opacity;
+
+    * {
+      box-sizing: border-box;
     }
-    #fractalOverlay[data-enabled="true"] { opacity: 1 }
-    #fractalOverlay canvas {
-      width: min(100%, 1100px);
-      height: auto;
-      border-radius: 1.75rem;
-      box-shadow: 0 32px 80px rgba(15,23,42,.22);
-      background: radial-gradient(circle at top, rgba(255,255,255,.08), rgba(15,23,42,.35));
+
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      background: var(--bg);
+      color: var(--fg);
     }
-    .dark #fractalOverlay canvas {
-      box-shadow: 0 32px 120px rgba(15,23,42,.55);
-      background: radial-gradient(circle at top, rgba(148,163,184,.08), rgba(2,6,23,.6));
-    }
-    button[data-fractal-toggle][data-state="active"] {
-      background-color: rgb(14 116 144);
-      border-color: rgba(8,145,178,.9);
-      color: #fff;
-      box-shadow: 0 14px 30px rgba(8,145,178,.28);
-    }
-    .dark button[data-fractal-toggle][data-state="active"] {
-      background-color: rgba(8,145,178,.85);
-      border-color: rgba(8,145,178,.75);
-      color: #f8fafc;
-      box-shadow: 0 16px 38px rgba(8,145,178,.42);
-    }
-    button[data-fractal-mode] {
-      position: relative;
+
+    body {
       overflow: hidden;
+      position: relative;
+      min-height: 100vh;
     }
-    button[data-fractal-mode]::after {
-      content: "";
-      position: absolute;
+
+    canvas#demo-canvas {
+      position: fixed;
       inset: 0;
-      z-index: -1;
-      opacity: .55;
-      transition: opacity .3s ease;
-      pointer-events: none;
+      width: 100vw;
+      height: 100vh;
+      display: block;
+      touch-action: none;
     }
-    button[data-fractal-mode][data-mode="aurora"]::after {
-      background: linear-gradient(120deg, rgba(56,189,248,.75), rgba(167,139,250,.65));
+
+    #control-bar {
+      position: fixed;
+      top: 1.25rem;
+      right: 1.25rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      padding: 0.75rem 1rem;
+      background: var(--bg-panel);
+      border: 1px solid var(--border);
+      border-radius: 0.75rem;
+      box-shadow: 0 1rem 2.5rem var(--shadow);
+      backdrop-filter: blur(10px);
+      z-index: 10;
     }
-    button[data-fractal-mode][data-mode="kaleidoscope"]::after {
-      background: linear-gradient(135deg, rgba(251,191,36,.75), rgba(244,114,182,.65));
+
+    #control-bar label {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      font-size: 0.85rem;
     }
-    button[data-fractal-mode][data-mode="golden"]::after {
-      background: linear-gradient(135deg, rgba(34,197,94,.72), rgba(234,179,8,.7));
+
+    #control-bar select,
+    #control-bar button,
+    #control-bar input[type="checkbox"],
+    #control-bar input[type="text"] {
+      font: inherit;
     }
-    button[data-fractal-mode]:hover::after,
-    button[data-fractal-mode]:focus-visible::after {
-      opacity: .88;
+
+    #control-bar button,
+    #control-bar select {
+      border-radius: 0.5rem;
+      border: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.08);
+      color: inherit;
+      padding: 0.35rem 0.65rem;
+      cursor: pointer;
+      transition: background 0.2s ease;
+    }
+
+    #control-bar button:hover,
+    #control-bar select:hover,
+    #control-bar button:focus-visible,
+    #control-bar select:focus-visible {
+      background: rgba(255, 255, 255, 0.15);
+      outline: none;
+    }
+
+    #control-bar button[aria-pressed="true"] {
+      background: rgba(247, 183, 51, 0.18);
+      border-color: rgba(247, 183, 51, 0.4);
+    }
+
+    #fps-meter {
+      min-width: 4rem;
+      text-align: right;
+      font-variant-numeric: tabular-nums;
+    }
+
+    #settings-panel {
+      position: fixed;
+      left: 1.25rem;
+      top: 1.25rem;
+      width: min(320px, 90vw);
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      padding: 1rem 1.25rem 1.5rem;
+      background: var(--bg-panel);
+      border: 1px solid var(--border);
+      border-radius: 0.75rem;
+      box-shadow: 0 1rem 2.5rem var(--shadow);
+      backdrop-filter: blur(10px);
+      z-index: 9;
+    }
+
+    #settings-panel header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    #settings-title {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 600;
+    }
+
+    #settings-form {
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    #settings-form .field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+      font-size: 0.85rem;
+    }
+
+    #settings-form .field input,
+    #settings-form .field select {
+      width: 100%;
+      border-radius: 0.5rem;
+      border: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.08);
+      color: inherit;
+      padding: 0.35rem 0.5rem;
+    }
+
+    #settings-form .field input[type="range"] {
+      accent-color: var(--accent);
+      padding: 0;
+    }
+
+    #settings-panel button {
+      font: inherit;
+      border-radius: 0.5rem;
+      border: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.12);
+      color: inherit;
+      padding: 0.35rem 0.65rem;
+      cursor: pointer;
+    }
+
+    #settings-panel button:hover,
+    #settings-panel button:focus-visible {
+      background: rgba(255, 255, 255, 0.2);
+      outline: none;
+    }
+
+    #explain-toggle {
+      display: flex;
+      align-items: center;
+      gap: 0.45rem;
+      font-size: 0.85rem;
+    }
+
+    #explain-panel {
+      position: fixed;
+      left: 1.25rem;
+      bottom: 1.25rem;
+      max-width: min(420px, 90vw);
+      padding: 0.85rem 1rem;
+      border-radius: 0.75rem;
+      border: 1px solid var(--border);
+      background: rgba(8, 10, 18, 0.85);
+      box-shadow: 0 1rem 2.5rem var(--shadow);
+      backdrop-filter: blur(10px);
+      font-size: 0.9rem;
+      line-height: 1.5;
+      z-index: 8;
+    }
+
+    #explain-panel h3 {
+      margin: 0 0 0.35rem;
+      font-size: 1rem;
+      font-weight: 600;
+    }
+
+    #explain-panel p {
+      margin: 0.25rem 0;
+    }
+
+    #explain-panel a {
+      color: var(--accent);
+    }
+
+    @media (max-width: 768px) {
+      #control-bar {
+        position: fixed;
+        top: auto;
+        bottom: 1rem;
+        right: 50%;
+        transform: translateX(50%);
+        width: min(90vw, 420px);
+        justify-content: center;
+      }
+
+      #settings-panel {
+        top: auto;
+        bottom: calc(1rem + 70px);
+        left: 50%;
+        transform: translateX(-50%);
+        width: min(95vw, 420px);
+      }
+
+      #explain-panel {
+        left: 50%;
+        bottom: calc(1rem + 70px + 220px);
+        transform: translateX(-50%);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
+    }
+
+    noscript {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.8);
+      color: #fff;
+      display: grid;
+      place-items: center;
+      font-size: 1.1rem;
+      padding: 2rem;
+      z-index: 100;
     }
   </style>
 </head>
-<body class="relative min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 text-slate-900 antialiased dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 dark:text-slate-100">
-  <div class="pointer-events-none absolute inset-0 overflow-hidden">
-    <div class="floating absolute -top-36 right-12 h-72 w-72 rounded-full bg-brand-500/10 blur-3xl dark:bg-brand-500/20"></div>
-    <div class="floating absolute bottom-0 left-[-6rem] h-64 w-64 rounded-full bg-brand-500/5 blur-3xl dark:bg-brand-500/15"></div>
-    <div class="absolute inset-x-0 top-24 mx-auto h-72 max-w-4xl rounded-full bg-white/60 blur-3xl dark:bg-slate-900/40"></div>
+<body>
+  <canvas id="demo-canvas" aria-label="Interactive mathematical visualizations" role="img"></canvas>
+
+  <div id="control-bar" role="region" aria-label="Global demo controls">
+    <label for="demo-select">Demo</label>
+    <select id="demo-select" name="demo-select" aria-label="Choose a mathematical demo"></select>
+    <button id="play-pause" type="button" aria-pressed="false" aria-label="Pause animation">Pause</button>
+    <label for="calm-toggle" title="Reduce motion and complexity">
+      <input type="checkbox" id="calm-toggle" name="calm-toggle" />
+      Calm Mode
+    </label>
+    <span id="fps-meter" aria-live="polite" aria-label="Frames per second">-- FPS</span>
+    <button id="download-btn" type="button" aria-label="Download current frame as PNG">Download PNG</button>
   </div>
 
-  <header data-header class="sticky top-0 z-30 border-b border-transparent transition-all duration-300">
-    <div class="mx-auto flex w-full max-w-5xl flex-wrap items-center justify-between gap-4 px-4 py-4 md:flex-nowrap md:py-6">
-      <a href="/links.html" class="flex items-center gap-3 rounded-full bg-white/70 px-4 py-2 text-sm font-semibold tracking-wide text-slate-700 backdrop-blur dark:bg-slate-900/60 dark:text-slate-200">
-        <span class="flex h-8 w-8 items-center justify-center rounded-full bg-brand-600 text-white">IJ</span>
-        Isaac Johnston
-      </a>
-      <div class="flex flex-wrap items-center justify-end gap-2 sm:gap-3">
-        <button id="themeToggle" type="button" class="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white/70 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-brand-500 hover:text-brand-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500 dark:border-slate-700 dark:bg-slate-950/60 dark:text-slate-200 dark:hover:border-brand-400 dark:hover:text-brand-200" title="Toggle light and dark theme">
-          <span aria-hidden="true">🌗</span>
-          Theme
-        </button>
-        <button data-fractal-toggle type="button" class="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white/70 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-brand-500 hover:text-brand-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500 dark:border-slate-700 dark:bg-slate-950/60 dark:text-slate-200 dark:hover:border-brand-400 dark:hover:text-brand-200" title="Launch the interactive fractal demo" data-state="inactive" aria-pressed="false">
-          <span aria-hidden="true">✨</span>
-          <span data-fractal-toggle-label>Launch demo</span>
-        </button>
-        <button data-fractal-mode type="button" class="hidden items-center gap-2 rounded-full border border-slate-300 bg-white/70 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-brand-500 hover:text-brand-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500 dark:border-slate-700 dark:bg-slate-950/60 dark:text-slate-200 dark:hover:border-brand-400 dark:hover:text-brand-200 sm:inline-flex" data-mode="aurora" title="Switch fractal style">
-          Mode: Aurora drift
-        </button>
-        <button data-fractal-shuffle type="button" class="hidden items-center gap-2 rounded-full border border-slate-300 bg-white/70 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-brand-500 hover:text-brand-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500 dark:border-slate-700 dark:bg-slate-950/60 dark:text-slate-200 dark:hover:border-brand-400 dark:hover:text-brand-200 sm:inline-flex" title="Generate a new fractal seed">
-          Shuffle
-        </button>
-      </div>
-    </div>
-    <nav class="mx-auto flex w-full max-w-5xl items-center justify-center gap-4 px-4 pb-3 text-sm font-medium text-slate-600 dark:text-slate-300 md:hidden">
-      <a class="transition hover:text-brand-600 dark:hover:text-brand-400" href="#focus">Focus</a>
-      <a class="transition hover:text-brand-600 dark:hover:text-brand-400" href="#projects">Projects</a>
-      <a class="transition hover:text-brand-600 dark:hover:text-brand-400" href="#about">About</a>
-      <a class="transition hover:text-brand-600 dark:hover:text-brand-400" href="#contact">Contact</a>
-    </nav>
-  </header>
-
-  <div id="fractalOverlay" data-enabled="false" aria-hidden="true">
-    <canvas id="fractalCanvas" aria-hidden="true"></canvas>
-  </div>
-
-  <main class="relative z-10 mx-auto flex w-full max-w-5xl flex-col gap-24 px-4 pb-24">
-    <section id="hero" class="fade-in relative overflow-hidden rounded-3xl border border-slate-200/70 bg-white/80 p-8 shadow-soft dark:border-slate-800/70 dark:bg-slate-950/60 md:p-12">
-      <div class="floating pointer-events-none absolute -top-24 left-1/3 h-60 w-60 rounded-full bg-brand-500/10 blur-3xl dark:bg-brand-500/20"></div>
-      <div class="relative grid gap-12 md:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)] md:items-start">
-        <div class="space-y-7">
-          <span class="inline-flex items-center gap-2 rounded-full border border-brand-200 bg-brand-50 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-brand-700 dark:border-brand-500/40 dark:bg-brand-500/10 dark:text-brand-200">Now building</span>
-          <h1 class="text-4xl font-extrabold leading-tight text-slate-900 dark:text-white md:text-5xl">Operator-minded builder helping teams launch resilient ventures.</h1>
-          <p class="text-lg text-slate-600 dark:text-slate-300">I partner with founders, property leaders, and community builders to move from idea to traction. My approach blends capital strategy, product experimentation, and operational rigor, grounded in clarity and integrity.</p>
-          <div class="flex flex-wrap gap-3">
-            <a href="https://calendar.app.google/V6WfbjRRDxbFr6X69" class="inline-flex items-center gap-2 rounded-full bg-brand-600 px-5 py-2.5 text-sm font-semibold text-white shadow-soft transition hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500">Book a 15‑min call</a>
-            <a href="/resume.pdf" class="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white/70 px-5 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-brand-500 hover:text-brand-600 dark:border-slate-700 dark:bg-slate-950/40 dark:text-slate-200 dark:hover:border-brand-400 dark:hover:text-brand-200">Download resume</a>
-            <a href="#projects" class="inline-flex items-center gap-2 rounded-full border border-transparent bg-slate-900/90 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-900 dark:bg-white/10 dark:text-white dark:hover:bg-white/20">Explore active projects</a>
-          </div>
-          <dl class="grid gap-4 sm:grid-cols-3">
-            <div class="rounded-2xl border border-slate-200/70 bg-white/80 p-4 shadow-soft dark:border-slate-800/60 dark:bg-slate-900/50">
-              <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">0 → 1 MVPs</dt>
-              <dd class="mt-2 text-sm text-slate-600 dark:text-slate-300">Hands-on support for Farm Compliance, student recruiting, and food ventures.</dd>
-            </div>
-            <div class="rounded-2xl border border-slate-200/70 bg-white/80 p-4 shadow-soft dark:border-slate-800/60 dark:bg-slate-900/50">
-              <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Operator minded</dt>
-              <dd class="mt-2 text-sm text-slate-600 dark:text-slate-300">Blend finance, growth, and compliance to unlock measurable progress.</dd>
-            </div>
-            <div class="rounded-2xl border border-slate-200/70 bg-white/80 p-4 shadow-soft dark:border-slate-800/60 dark:bg-slate-900/50">
-              <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Principled partner</dt>
-              <dd class="mt-2 text-sm text-slate-600 dark:text-slate-300">Lead with values that prioritize clarity, trust, and long-term stewardship.</dd>
-            </div>
-          </dl>
-        </div>
-        <div class="relative">
-          <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70">
-            <div class="flex items-center justify-between gap-4">
-              <span class="inline-flex items-center gap-2 rounded-full bg-brand-500/15 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-brand-700 dark:text-brand-200"><span aria-hidden="true">⚡️</span> Current focus</span>
-              <span class="text-xs text-slate-500 dark:text-slate-400">Updated weekly</span>
-            </div>
-            <p class="mt-4 text-sm text-slate-600 dark:text-slate-300">These are the hands-on sprints I’m running inside the initiatives detailed in the Projects section below. Consider them the in-flight tasks powering each venture’s status.</p>
-            <ul class="mt-6 space-y-4 text-sm text-slate-600 dark:text-slate-300">
-              <li class="flex gap-3">
-                <span class="mt-1 text-brand-600">▹</span>
-                <span><strong>Farm Compliance MVP (in development):</strong> rolling out multilingual onboarding flows and audit-ready checklists for southeastern growers.</span>
-              </li>
-              <li class="flex gap-3">
-                <span class="mt-1 text-brand-600">▹</span>
-                <span><strong>UNCC Student Network (active):</strong> expanding a talent marketplace that connects students with operators and recruiters.</span>
-              </li>
-              <li class="flex gap-3">
-                <span class="mt-1 text-brand-600">▹</span>
-                <span><strong>Cali Baking MVP (in development):</strong> testing new product drops and local delivery partnerships for a growing food brand.</span>
-              </li>
-            </ul>
-            <div class="mt-8 rounded-2xl border border-dashed border-brand-500/40 bg-brand-500/5 p-5 text-sm text-slate-600 dark:border-brand-500/30 dark:text-slate-200">
-              <p class="font-semibold text-brand-700 dark:text-brand-200">Exploring</p>
-              <p class="mt-1">Angel-backed real estate plays, community revitalization projects, and operator-in-residence opportunities.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section id="focus" class="space-y-8">
-      <div class="space-y-2 text-center">
-        <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600 dark:text-brand-300">Focus areas</p>
-        <h2 class="text-3xl font-bold text-slate-900 dark:text-white">Where I create leverage</h2>
-        <p class="mx-auto max-w-3xl text-base text-slate-600 dark:text-slate-300">My sweet spot is collaborating with founders and operators who need a strategic generalist: someone who can model capital stacks, ship product experiments, and activate community distribution.</p>
-      </div>
-      <div class="grid gap-6 md:grid-cols-2">
-        <article class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-800/70 dark:bg-slate-950/60">
-          <div class="flex items-center gap-3 text-brand-600 dark:text-brand-300">
-            <span class="text-2xl">🏢</span>
-            <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Real estate &amp; capital strategy</h3>
-          </div>
-          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Underwriting, creative financing structures, and community partnerships to turn underutilized assets into thriving hubs.</p>
-        </article>
-        <article class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-800/70 dark:bg-slate-950/60">
-          <div class="flex items-center gap-3 text-brand-600 dark:text-brand-300">
-            <span class="text-2xl">🛠️</span>
-            <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Product &amp; growth experimentation</h3>
-          </div>
-          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Rapid sprints, customer interviews, and data-informed pilots that validate demand before scaling operations.</p>
-        </article>
-        <article class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-800/70 dark:bg-slate-950/60">
-          <div class="flex items-center gap-3 text-brand-600 dark:text-brand-300">
-            <span class="text-2xl">🤝</span>
-            <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Community &amp; partnerships</h3>
-          </div>
-          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Building coalitions across universities, small businesses, and local communities to amplify opportunity.</p>
-        </article>
-        <article class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-800/70 dark:bg-slate-950/60">
-          <div class="flex items-center gap-3 text-brand-600 dark:text-brand-300">
-            <span class="text-2xl">🧭</span>
-            <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Operational excellence</h3>
-          </div>
-          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Designing checklists, onboarding flows, and playbooks that keep teams accountable to mission and metrics.</p>
-        </article>
-      </div>
-    </section>
-
-    <section id="projects" class="space-y-8">
-      <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
-        <div>
-          <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600 dark:text-brand-300">Projects</p>
-          <h2 class="text-3xl font-bold text-slate-900 dark:text-white">Building with operators in the field</h2>
-          <p class="mt-2 max-w-2xl text-sm text-slate-600 dark:text-slate-300">Status badges reflect where each initiative sits today, complementing the “Current focus” sprints above so you can see both the week-to-week work and the broader milestone.</p>
-        </div>
-        <a href="#contact" class="inline-flex items-center gap-2 text-sm font-semibold text-brand-600 transition hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200">Share an opportunity →</a>
-      </div>
-      <div class="space-y-6">
-        <a href="/projects/farm-compliance.html" class="group block rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500 dark:border-slate-800/70 dark:bg-slate-950/60" aria-label="Farm Compliance MVP project overview">
-          <div class="flex items-center justify-between gap-4">
-            <h3 class="text-xl font-semibold text-slate-900 dark:text-white">Farm Compliance MVP</h3>
-            <span class="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:bg-amber-500/20 dark:text-amber-100">In development</span>
-          </div>
-          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">A multilingual onboarding and audit preparation toolkit in build-mode to keep growers aligned with labor, safety, and food-handling standards before the public beta.</p>
-          <ul class="mt-4 space-y-2 text-sm text-slate-600 dark:text-slate-300">
-            <li class="flex gap-2"><span class="text-brand-600">•</span> Implemented mobile-first checklists with offline sync for in-field teams.</li>
-            <li class="flex gap-2"><span class="text-brand-600">•</span> Partnering with agronomists to co-create compliance education modules.</li>
-          </ul>
-          <span class="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-brand-600 transition group-hover:text-brand-500 dark:text-brand-300 dark:group-hover:text-brand-200">View project overview<span aria-hidden="true">→</span></span>
-        </a>
-        <a href="/projects/uncc-student-network.html" class="group block rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500 dark:border-slate-800/70 dark:bg-slate-950/60" aria-label="UNCC Student Network project overview">
-          <div class="flex items-center justify-between gap-4">
-            <h3 class="text-xl font-semibold text-slate-900 dark:text-white">UNCC Student Network</h3>
-            <span class="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-100">Active</span>
-          </div>
-          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Community-driven recruiting that connects students with startups, growth-stage companies, and civic projects across Charlotte. Currently running meetups and matching talent with operator roles.</p>
-          <ul class="mt-4 space-y-2 text-sm text-slate-600 dark:text-slate-300">
-            <li class="flex gap-2"><span class="text-brand-600">•</span> Launching micro-events and office hours to surface talent.</li>
-            <li class="flex gap-2"><span class="text-brand-600">•</span> Coordinating hiring pipelines for internships and operator residencies.</li>
-          </ul>
-          <span class="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-brand-600 transition group-hover:text-brand-500 dark:text-brand-300 dark:group-hover:text-brand-200">View project overview<span aria-hidden="true">→</span></span>
-        </a>
-        <a href="/projects/cali-baking.html" class="group block rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500 dark:border-slate-800/70 dark:bg-slate-950/60" aria-label="Cali Baking MVP project overview">
-          <div class="flex items-center justify-between gap-4">
-            <h3 class="text-xl font-semibold text-slate-900 dark:text-white">Cali Baking MVP</h3>
-            <span class="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:bg-amber-500/20 dark:text-amber-100">In development</span>
-          </div>
-          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Experiments in e-commerce, delivery, and subscription models that scale a beloved local bakery beyond brick-and-mortar, still validating before a public launch.</p>
-          <ul class="mt-4 space-y-2 text-sm text-slate-600 dark:text-slate-300">
-            <li class="flex gap-2"><span class="text-brand-600">•</span> Built drop schedules and SMS waitlists to drive limited releases.</li>
-            <li class="flex gap-2"><span class="text-brand-600">•</span> Testing partnerships with coffee shops and community markets.</li>
-          </ul>
-          <span class="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-brand-600 transition group-hover:text-brand-500 dark:text-brand-300 dark:group-hover:text-brand-200">View project overview<span aria-hidden="true">→</span></span>
-        </a>
-      </div>
-    </section>
-
-    <section id="journey" class="space-y-8">
-      <div class="space-y-2 text-center">
-        <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600 dark:text-brand-300">Journey</p>
-        <h2 class="text-3xl font-bold text-slate-900 dark:text-white">A path shaped by service and execution</h2>
-        <p class="mx-auto max-w-3xl text-base text-slate-600 dark:text-slate-300">From real estate deals to campus ecosystems, I lead with empathy, data, and the conviction that business can uplift communities.</p>
-      </div>
-      <ol class="relative space-y-6 border-l border-slate-200 pl-6 dark:border-slate-800">
-        <li class="relative">
-          <span class="absolute -left-[13px] mt-1 h-3 w-3 rounded-full border border-brand-500 bg-white dark:border-brand-400 dark:bg-slate-950"></span>
-          <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-5 shadow-soft dark:border-slate-800/70 dark:bg-slate-950/60">
-            <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Real estate investing &amp; capital advisory</h3>
-            <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Structured creative deals, underwrote acquisitions, and supported operators with go-to-market plans backed by disciplined financial models.</p>
-          </div>
-        </li>
-        <li class="relative">
-          <span class="absolute -left-[13px] mt-1 h-3 w-3 rounded-full border border-brand-500 bg-white dark:border-brand-400 dark:bg-slate-950"></span>
-          <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-5 shadow-soft dark:border-slate-800/70 dark:bg-slate-950/60">
-            <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Community leadership &amp; service</h3>
-            <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Organized mentorship initiatives, resource drives, and practical support for families and students across the Carolinas.</p>
-          </div>
-        </li>
-        <li class="relative">
-          <span class="absolute -left-[13px] mt-1 h-3 w-3 rounded-full border border-brand-500 bg-white dark:border-brand-400 dark:bg-slate-950"></span>
-          <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-5 shadow-soft dark:border-slate-800/70 dark:bg-slate-950/60">
-            <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Startup operator &amp; advisor</h3>
-            <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Guiding teams through MVP launches, analytics instrumentation, and partnership development to reach early proof points.</p>
-          </div>
-        </li>
-      </ol>
-    </section>
-
-    <section id="links" class="space-y-8">
-      <div class="space-y-2 text-center">
-        <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600 dark:text-brand-300">Quick links</p>
-        <h2 class="text-3xl font-bold text-slate-900 dark:text-white">Dive deeper</h2>
-        <p class="mx-auto max-w-3xl text-base text-slate-600 dark:text-slate-300">Resources, calendars, and artifacts to learn more about my work. Save what resonates or share it with someone who might benefit.</p>
-      </div>
-      <div class="grid gap-5 sm:grid-cols-2">
-        <a class="group rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-800/70 dark:bg-slate-950/60" href="/resume.pdf">
-          <div class="flex items-center justify-between">
-            <div class="text-lg font-semibold text-slate-900 dark:text-white">Resume</div>
-            <span class="text-xl">📄</span>
-          </div>
-          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">One-page overview of roles, projects, and impact.</p>
-          <p class="mt-4 text-sm font-semibold text-brand-600 dark:text-brand-300">Download PDF →</p>
-        </a>
-        <a class="group rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-800/70 dark:bg-slate-950/60" href="https://calendar.app.google/V6WfbjRRDxbFr6X69">
-          <div class="flex items-center justify-between">
-            <div class="text-lg font-semibold text-slate-900 dark:text-white">Book time</div>
-            <span class="text-xl">🗓️</span>
-          </div>
-          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">15-minute intro chats to explore partnerships or brainstorm ideas.</p>
-          <p class="mt-4 text-sm font-semibold text-brand-600 dark:text-brand-300">Book via Google Calendar →</p>
-        </a>
-        <a class="group rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-800/70 dark:bg-slate-950/60" href="mailto:isaacinpursuit@gmail.com">
-          <div class="flex items-center justify-between">
-            <div class="text-lg font-semibold text-slate-900 dark:text-white">Email</div>
-            <span class="text-xl">✉️</span>
-          </div>
-          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Reach me directly with opportunities, questions, or introductions.</p>
-          <p class="mt-4 text-sm font-semibold text-brand-600 dark:text-brand-300">isaacinpursuit@gmail.com</p>
-        </a>
-        <a class="group rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-800/70 dark:bg-slate-950/60" href="https://www.linkedin.com/in/isaacinpursuit/">
-          <div class="flex items-center justify-between">
-            <div class="text-lg font-semibold text-slate-900 dark:text-white">LinkedIn</div>
-            <span class="text-xl">🔗</span>
-          </div>
-          <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Connect professionally and follow along with weekly build notes.</p>
-          <p class="mt-4 text-sm font-semibold text-brand-600 dark:text-brand-300">View profile →</p>
-        </a>
-      </div>
-    </section>
-
-    <section id="about" class="space-y-8">
-      <div class="space-y-2 text-center">
-        <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600 dark:text-brand-300">About</p>
-        <h2 class="text-3xl font-bold text-slate-900 dark:text-white">Guided by principles, focused on impact</h2>
-      </div>
-      <div class="grid gap-10 md:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] md:items-start">
-        <div class="space-y-4 text-base leading-relaxed text-slate-600 dark:text-slate-300">
-          <p>I build at the intersection of real estate, finance, and entrepreneurship. Each chapter of my career has been rooted in a commitment to serve people, steward resources well, and grow communities with integrity.</p>
-          <p>Whether structuring a deal, prototyping an MVP, or facilitating a partnership, I obsess over clarity, measurable outcomes, and the human beings affected by the work. Excellence should open doors for others and compound long-term impact.</p>
-        </div>
-        <div class="space-y-4">
-          <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft dark:border-slate-800/70 dark:bg-slate-950/60">
-            <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Values I bring to every room</h3>
-            <ul class="mt-4 space-y-3 text-sm text-slate-600 dark:text-slate-300">
-              <li class="flex gap-3"><span class="mt-1 text-brand-600">▹</span><span><strong>Stewardship:</strong> Treat capital, time, and trust as gifts to be multiplied.</span></li>
-              <li class="flex gap-3"><span class="mt-1 text-brand-600">▹</span><span><strong>Clarity:</strong> Communicate strategy and next actions so teams stay aligned.</span></li>
-              <li class="flex gap-3"><span class="mt-1 text-brand-600">▹</span><span><strong>Presence:</strong> Show up for people beyond the deal through mentorship, encouragement, and follow-through.</span></li>
-            </ul>
-          </div>
-          <div class="rounded-3xl border border-dashed border-brand-500/40 bg-brand-500/5 p-6 text-sm text-slate-600 dark:border-brand-500/30 dark:text-slate-200">
-            <p class="font-semibold text-brand-700 dark:text-brand-200">Let’s collaborate</p>
-            <p class="mt-2">If you’re building something that needs a strategic operator with a service-oriented mindset, I’d love to connect.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section id="contact" class="space-y-8">
-      <div class="space-y-2 text-center">
-        <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600 dark:text-brand-300">Contact</p>
-        <h2 class="text-3xl font-bold text-slate-900 dark:text-white">Let’s start a conversation</h2>
-        <p class="mx-auto max-w-2xl text-base text-slate-600 dark:text-slate-300">Share what you’re building, where you’re feeling stuck, or how we might co-create impact. I read every message.</p>
-      </div>
-      <div class="grid gap-10 md:grid-cols-2 md:items-start">
-        <form action="https://formspree.io/f/mkgnjopd" method="POST" data-form class="space-y-5 rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft dark:border-slate-800/70 dark:bg-slate-950/60">
-          <div class="space-y-2">
-            <label class="block text-sm font-semibold text-slate-700 dark:text-slate-200" for="name">Name</label>
-            <input required id="name" type="text" name="name" placeholder="Your name" class="w-full rounded-2xl border border-slate-300 bg-white/90 px-4 py-3 text-sm text-slate-900 transition focus:border-brand-500 focus:outline-none dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100" />
-          </div>
-          <div class="space-y-2">
-            <label class="block text-sm font-semibold text-slate-700 dark:text-slate-200" for="email">Email</label>
-            <input required id="email" type="email" name="email" placeholder="you@example.com" class="w-full rounded-2xl border border-slate-300 bg-white/90 px-4 py-3 text-sm text-slate-900 transition focus:border-brand-500 focus:outline-none dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100" />
-          </div>
-          <div class="space-y-2">
-            <label class="block text-sm font-semibold text-slate-700 dark:text-slate-200" for="message">Message</label>
-            <textarea required id="message" name="message" rows="5" placeholder="What are you exploring?" class="w-full rounded-2xl border border-slate-300 bg-white/90 px-4 py-3 text-sm text-slate-900 transition focus:border-brand-500 focus:outline-none dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100"></textarea>
-          </div>
-          <div class="space-y-3">
-            <button class="w-full rounded-2xl bg-brand-600 px-4 py-3 text-sm font-semibold text-white shadow-soft transition hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500">Send message</button>
-            <p class="text-xs text-slate-500 dark:text-slate-400">Powered by Formspree. Prefer email? <a class="font-medium text-brand-600 hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200" href="mailto:isaacinpursuit@gmail.com">isaacinpursuit@gmail.com</a>.</p>
-            <p data-form-status role="status" aria-live="polite" class="hidden text-sm font-medium text-brand-600 dark:text-brand-300"></p>
-          </div>
-        </form>
-        <div class="space-y-6">
-          <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft dark:border-slate-800/70 dark:bg-slate-950/60">
-            <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Prefer a direct line?</h3>
-            <ul class="mt-4 space-y-3 text-sm text-slate-600 dark:text-slate-300">
-              <li><a class="inline-flex items-center gap-2 text-brand-600 transition hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200" href="mailto:isaacinpursuit@gmail.com"><span aria-hidden="true">✉️</span> isaacinpursuit@gmail.com</a></li>
-              <li><a class="inline-flex items-center gap-2 text-brand-600 transition hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200" href="https://calendar.app.google/V6WfbjRRDxbFr6X69"><span aria-hidden="true">🗓️</span> Book intro call</a></li>
-              <li><a class="inline-flex items-center gap-2 text-brand-600 transition hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200" href="https://www.linkedin.com/in/isaacinpursuit/"><span aria-hidden="true">💼</span> LinkedIn updates</a></li>
-            </ul>
-          </div>
-          <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft dark:border-slate-800/70 dark:bg-slate-950/60">
-            <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Book a meeting</h3>
-            <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Reserve a 15-minute slot on my Google appointment schedule for quick intros or project scoping.</p>
-            <a href="https://calendar.app.google/V6WfbjRRDxbFr6X69" class="mt-4 inline-flex items-center justify-center gap-2 rounded-2xl bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white shadow-soft transition hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500">Book via Google Calendar</a>
-          </div>
-          <div class="rounded-3xl border border-dashed border-brand-500/40 bg-brand-500/5 p-6 text-sm text-slate-600 dark:border-brand-500/30 dark:text-slate-200">
-            <p class="font-semibold text-brand-700 dark:text-brand-200">Looking for a collaborator?</p>
-            <p class="mt-2">Bring me in to evaluate a deal, run a sprint, or mentor a team. I’ll map the path to traction with you.</p>
-          </div>
-        </div>
-      </div>
-      <div class="rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-soft dark:border-slate-800/70 dark:bg-slate-950/60">
-        <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Alternate intake form</h3>
-        <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Prefer a structured questionnaire? Submit the Google Form below. It routes to the same inbox and helps me prep before we connect.</p>
-        <div class="mt-5 overflow-hidden rounded-2xl border border-slate-200 bg-white/90 shadow-inner dark:border-slate-800 dark:bg-slate-900/40">
-          <iframe title="Google intake form" src="https://forms.gle/QEEHH4ic7yET2B9p9" loading="lazy" class="h-[640px] w-full" allowfullscreen></iframe>
-        </div>
-        <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">If the form doesn’t load, <a class="font-medium text-brand-600 hover:text-brand-500 dark:text-brand-300 dark:hover:text-brand-200" href="https://forms.gle/QEEHH4ic7yET2B9p9" target="_blank" rel="noopener">open it in a new tab</a>.</p>
-      </div>
-    </section>
-  </main>
-
-  <a href="#hero" data-back-to-top class="fixed bottom-6 right-6 z-40 inline-flex items-center gap-2 rounded-full bg-slate-900/90 px-4 py-2 text-sm font-semibold text-white shadow-soft transition hover:bg-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500 dark:bg-white/10 dark:text-white dark:hover:bg-white/20 opacity-0 pointer-events-none translate-y-4">Back to top<span aria-hidden="true">↑</span></a>
-
-  <footer class="relative z-10 mx-auto mt-12 flex w-full max-w-5xl flex-col items-center gap-3 px-4 pb-10 text-center text-xs text-slate-500 dark:text-slate-400">
-    <p>© <span id="year"></span> Isaac Johnston. Built with persistence, craft, and plenty of coffee.</p>
-    <p class="flex flex-wrap justify-center gap-4">
-      <a class="hover:text-brand-600 dark:hover:text-brand-300" href="#hero">Back to top</a>
-      <a class="hover:text-brand-600 dark:hover:text-brand-300" href="/links.html">More resources</a>
-      <a class="hover:text-brand-600 dark:hover:text-brand-300" href="mailto:isaacinpursuit@gmail.com">Say hello</a>
-    </p>
-  </footer>
-
-  <script>
-    // Theme persistence
-    const applyTheme = () => {
-      if (localStorage.theme === 'dark' || (!('theme' in localStorage) && matchMedia('(prefers-color-scheme: dark)').matches)) {
-        document.documentElement.classList.add('dark')
-      } else {
-        document.documentElement.classList.remove('dark')
-      }
-    }
-    applyTheme();
-    document.getElementById('themeToggle')?.addEventListener('click', () => {
-      const isDark = document.documentElement.classList.toggle('dark');
-      localStorage.theme = isDark ? 'dark' : 'light';
-    });
-
-    // Fractal demo overlay
-    (() => {
-      const wrap = document.getElementById('fractalOverlay');
-      const canvas = document.getElementById('fractalCanvas');
-      if (!wrap || !canvas) return;
-      const ctx = canvas.getContext('2d');
-      if (!ctx) return;
-
-      const toggleButton = document.querySelector('[data-fractal-toggle]');
-      const modeButton = document.querySelector('[data-fractal-mode]');
-      const shuffleButton = document.querySelector('[data-fractal-shuffle]');
-      const themeButton = document.getElementById('themeToggle');
-
-      const MODE_STORAGE_KEY = 'fractaldemo:mode';
-      const FRACTAL_MODES = ['aurora', 'kaleidoscope', 'golden'];
-      const FRACTAL_MODE_LABELS = {
-        aurora: 'Aurora drift',
-        kaleidoscope: 'Kaleidoscope',
-        golden: 'Golden bloom',
-      };
-      const FRACTAL_MODE_DESCRIPTIONS = {
-        aurora: 'Layered aurora noise fields',
-        kaleidoscope: 'Mirrored sacred-geometry kaleidoscope',
-        golden: 'Golden-ratio phyllotaxis tree',
-      };
-
-      function mulberry32(seed) {
-        return function () {
-          let t = (seed += 0x6d2b79f5);
-          t = Math.imul(t ^ (t >>> 15), t | 1);
-          t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-          return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-        };
-      }
-
-      function makeNoise(seed) {
-        const rand = mulberry32(seed);
-        const gradients = [];
-        for (let i = 0; i < 256; i++) {
-          gradients.push({ x: rand() * 2 - 1, y: rand() * 2 - 1 });
-        }
-        const perm = new Uint8Array(512);
-        for (let i = 0; i < 512; i++) perm[i] = i & 255;
-        for (let i = 0; i < 256; i++) {
-          const j = (rand() * 256) | 0;
-          const tmp = perm[i];
-          perm[i] = perm[j];
-          perm[j] = tmp;
-          perm[i + 256] = perm[i];
-        }
-        const fade = t => t * t * t * (t * (t * 6 - 15) + 10);
-        const lerp = (a, b, t) => a + t * (b - a);
-
-        function grad(ix, iy, x, y) {
-          const g = gradients[perm[(ix + perm[iy & 255]) & 255]];
-          return g.x * (x - ix) + g.y * (y - iy);
-        }
-
-        return (x, y) => {
-          const x0 = Math.floor(x);
-          const y0 = Math.floor(y);
-          const u = fade(x - x0);
-          const v = fade(y - y0);
-          const n00 = grad(x0, y0, x, y);
-          const n10 = grad(x0 + 1, y0, x, y);
-          const n01 = grad(x0, y0 + 1, x, y);
-          const n11 = grad(x0 + 1, y0 + 1, x, y);
-          return lerp(lerp(n00, n10, u), lerp(n01, n11, u), v);
-        };
-      }
-
-      function randomSeed() {
-        if (globalThis.crypto && typeof globalThis.crypto.getRandomValues === 'function') {
-          const values = new Uint32Array(1);
-          globalThis.crypto.getRandomValues(values);
-          return values[0];
-        }
-        return (Math.random() * 0xffffffff) >>> 0;
-      }
-
-      function parseCssColor(value) {
-        const color = value.trim();
-        if (!color) return null;
-        const hexMatch = color.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
-        if (hexMatch) {
-          let hex = hexMatch[1];
-          if (hex.length === 3) {
-            hex = hex
-              .split('')
-              .map(char => char + char)
-              .join('');
-          }
-          const r = parseInt(hex.slice(0, 2), 16);
-          const g = parseInt(hex.slice(2, 4), 16);
-          const b = parseInt(hex.slice(4, 6), 16);
-          if (Number.isFinite(r) && Number.isFinite(g) && Number.isFinite(b)) {
-            return { r, g, b };
-          }
-        }
-        const rgbMatch = color.match(/^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})(?:\s*,\s*([\d.]+))?\s*\)$/i);
-        if (rgbMatch) {
-          const clamp = v => Math.max(0, Math.min(255, v | 0));
-          const r = clamp(parseInt(rgbMatch[1], 10));
-          const g = clamp(parseInt(rgbMatch[2], 10));
-          const b = clamp(parseInt(rgbMatch[3], 10));
-          if (Number.isFinite(r) && Number.isFinite(g) && Number.isFinite(b)) {
-            return { r, g, b };
-          }
-        }
-        return null;
-      }
-
-      function persistMode(value) {
-        try {
-          localStorage.setItem(MODE_STORAGE_KEY, value);
-        } catch (error) {
-          // Ignore storage write failures (private mode, etc.)
-        }
-      }
-
-      function loadStoredMode() {
-        try {
-          const stored = localStorage.getItem(MODE_STORAGE_KEY);
-          if (stored && FRACTAL_MODES.includes(stored)) {
-            return stored;
-          }
-        } catch (error) {
-          // Ignore storage read failures
-        }
-        return FRACTAL_MODES[Math.floor(Math.random() * FRACTAL_MODES.length)];
-      }
-
-      let seed = randomSeed();
-      let mode = loadStoredMode();
-      let noise = makeNoise(seed);
-      let enabled = false;
-      let dpr = 1;
-      let pendingFrame = false;
-      let latestScrollY = window.scrollY;
-      let reduceMotion = false;
-
-      const reduceMotionMedia = window.matchMedia?.('(prefers-reduced-motion: reduce)');
-      if (reduceMotionMedia) {
-        reduceMotion = reduceMotionMedia.matches;
-        const handleReduceChange = event => {
-          reduceMotion = event.matches;
-          if (reduceMotion) {
-            wrap.style.transform = '';
-          } else if (enabled) {
-            handleScroll();
-          }
-          scheduleRender();
-        };
-        if (typeof reduceMotionMedia.addEventListener === 'function') {
-          reduceMotionMedia.addEventListener('change', handleReduceChange);
-        } else if (typeof reduceMotionMedia.addListener === 'function') {
-          reduceMotionMedia.addListener(handleReduceChange);
-        }
-      }
-
-      const schemeMedia = window.matchMedia?.('(prefers-color-scheme: dark)');
-      if (schemeMedia) {
-        const handleSchemeChange = () => scheduleRender();
-        if (typeof schemeMedia.addEventListener === 'function') {
-          schemeMedia.addEventListener('change', handleSchemeChange);
-        } else if (typeof schemeMedia.addListener === 'function') {
-          schemeMedia.addListener(handleSchemeChange);
-        }
-      }
-
-      let classObserver;
-      if (typeof MutationObserver !== 'undefined') {
-        classObserver = new MutationObserver(() => scheduleRender());
-        classObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
-        window.addEventListener(
-          'beforeunload',
-          () => {
-            classObserver?.disconnect();
-          },
-          { once: true }
-        );
-      }
-
-      function setSeed(value) {
-        seed = value >>> 0;
-        noise = makeNoise(seed);
-      }
-
-      function updateButtons() {
-        if (toggleButton) {
-          toggleButton.setAttribute('data-state', enabled ? 'active' : 'inactive');
-          toggleButton.setAttribute('aria-pressed', enabled ? 'true' : 'false');
-          toggleButton.setAttribute('aria-label', enabled ? 'Hide fractal demo' : 'Launch fractal demo');
-          toggleButton.setAttribute('title', enabled ? 'Hide the interactive fractal demo' : 'Launch the interactive fractal demo');
-          const labelEl = toggleButton.querySelector('[data-fractal-toggle-label]');
-          if (labelEl) {
-            labelEl.textContent = enabled ? 'Hide demo' : 'Launch demo';
-          }
-        }
-        if (modeButton) {
-          modeButton.dataset.mode = mode;
-          modeButton.textContent = `Mode: ${FRACTAL_MODE_LABELS[mode]}`;
-          modeButton.setAttribute('title', `Switch fractal style – ${FRACTAL_MODE_DESCRIPTIONS[mode]}`);
-          modeButton.setAttribute('aria-label', `Fractal mode: ${FRACTAL_MODE_LABELS[mode]}`);
-        }
-        wrap.setAttribute('data-mode', mode);
-      }
-
-      function scheduleRender() {
-        if (!enabled || pendingFrame) return;
-        pendingFrame = true;
-        requestAnimationFrame(() => {
-          pendingFrame = false;
-          render();
-        });
-      }
-
-      function handleResize() {
-        if (!enabled) return;
-        const padding = window.innerWidth < 640 ? 28 : 48;
-        const availableWidth = Math.max(320, window.innerWidth - padding);
-        const width = Math.min(availableWidth, 1100);
-        const height = Math.max(320, Math.min(640, width * 0.62, window.innerHeight * 0.65));
-        dpr = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
-        canvas.width = Math.floor(width * dpr);
-        canvas.height = Math.floor(height * dpr);
-        canvas.style.width = `${width}px`;
-        canvas.style.height = `${height}px`;
-        scheduleRender();
-      }
-
-      function handleScroll() {
-        if (!enabled) return;
-        latestScrollY = window.scrollY;
-        if (reduceMotion) {
-          wrap.style.transform = '';
-        } else {
-          wrap.style.transform = `translateY(${latestScrollY * 0.12}px)`;
-        }
-        scheduleRender();
-      }
-
-      function handleKeyDown(event) {
-        if (event.key === 'Escape') {
-          disable();
-        }
-      }
-
-      function enable() {
-        if (enabled) return;
-        enabled = true;
-        wrap.dataset.enabled = 'true';
-        wrap.setAttribute('aria-hidden', 'false');
-        setSeed(seed);
-        handleResize();
-        handleScroll();
-        window.addEventListener('resize', handleResize);
-        window.addEventListener('scroll', handleScroll, { passive: true });
-        window.addEventListener('keydown', handleKeyDown);
-        scheduleRender();
-        updateButtons();
-      }
-
-      function disable() {
-        if (!enabled) return;
-        enabled = false;
-        wrap.dataset.enabled = 'false';
-        wrap.setAttribute('aria-hidden', 'true');
-        wrap.style.transform = '';
-        window.removeEventListener('resize', handleResize);
-        window.removeEventListener('scroll', handleScroll);
-        window.removeEventListener('keydown', handleKeyDown);
-        updateButtons();
-      }
-
-      function render() {
-        if (!enabled) return;
-        const width = canvas.width;
-        const height = canvas.height;
-        if (!width || !height) return;
-        ctx.save();
-        ctx.setTransform(1, 0, 0, 1, 0, 0);
-        ctx.clearRect(0, 0, width, height);
-        ctx.restore();
-        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-
-        const viewWidth = width / dpr;
-        const viewHeight = height / dpr;
-        const styles = getComputedStyle(document.documentElement);
-        const bg = styles.getPropertyValue('--fract-bg').trim() || '#0f172a';
-        const fgRaw = styles.getPropertyValue('--fract-fg').trim() || '#f8fafc';
-        const fgColor = parseCssColor(fgRaw) || { r: 248, g: 250, b: 252 };
-
-        ctx.globalAlpha = 1;
-        ctx.fillStyle = bg;
-        ctx.fillRect(0, 0, viewWidth, viewHeight);
-
-        const scrollShift = ((latestScrollY % 2400) + 2400) / 2400;
-
-        switch (mode) {
-          case 'kaleidoscope':
-            renderKaleidoscope(viewWidth, viewHeight, fgColor, scrollShift);
-            break;
-          case 'golden':
-            renderGolden(viewWidth, viewHeight, fgColor, scrollShift);
-            break;
-          default:
-            renderAurora(viewWidth, viewHeight, fgColor, scrollShift);
-            break;
-        }
-
-        ctx.globalAlpha = 1;
-        const vignette = ctx.createRadialGradient(
-          viewWidth / 2,
-          viewHeight / 2,
-          12,
-          viewWidth / 2,
-          viewHeight / 2,
-          Math.max(viewWidth, viewHeight) / 1.15
-        );
-        vignette.addColorStop(0, 'rgba(0,0,0,0)');
-        vignette.addColorStop(1, 'rgba(2,6,23,0.22)');
-        ctx.fillStyle = vignette;
-        ctx.fillRect(0, 0, viewWidth, viewHeight);
-      }
-
-      function renderAurora(viewWidth, viewHeight, fgColor, scrollShift) {
-        const step = Math.max(3.5, (4 * Math.max(1, Math.round(dpr))) / dpr);
-        ctx.save();
-        for (let y = 0; y < viewHeight; y += step) {
-          for (let x = 0; x < viewWidth; x += step) {
-            const sampleX = x * dpr * 0.85;
-            const sampleY = y * dpr * 0.85;
-            const n = noise(sampleX + seed * 0.00032, sampleY + seed * 0.00058);
-            const t = (n + 1) / 2;
-            const hue = (scrollShift * 360 + x * 0.18 + y * 0.12) % 360;
-            const lightness = 45 + t * 40;
-            const alpha = 0.32 + t * 0.55;
-            ctx.fillStyle = `hsla(${(hue + 360) % 360}, 82%, ${Math.min(82, Math.max(36, lightness))}%, ${alpha})`;
-            ctx.fillRect(x, y, step, step);
-          }
-        }
-        ctx.globalCompositeOperation = 'lighter';
-        ctx.fillStyle = `rgba(${fgColor.r}, ${fgColor.g}, ${fgColor.b}, 0.12)`;
-        ctx.fillRect(0, 0, viewWidth, viewHeight);
-        ctx.globalCompositeOperation = 'source-over';
-        ctx.restore();
-      }
-
-      function renderKaleidoscope(viewWidth, viewHeight, fgColor, scrollShift) {
-        const step = Math.max(2.5, (3.6 * Math.max(1, Math.round(dpr))) / dpr);
-        const centerX = viewWidth / 2;
-        const centerY = viewHeight / 2;
-        const segmentAngle = (Math.PI * 2) / 6;
-        const paletteShift = (seed % 720) / 720 * 360 + scrollShift * 180;
-
-        ctx.save();
-        for (let y = 0; y < viewHeight; y += step) {
-          for (let x = 0; x < viewWidth; x += step) {
-            const dx = x - centerX;
-            const dy = y - centerY;
-            const radius = Math.hypot(dx, dy);
-            let angle = Math.atan2(dy, dx);
-            if (Number.isNaN(angle)) angle = 0;
-            angle = angle % segmentAngle;
-            if (angle < 0) angle += segmentAngle;
-            if (angle > segmentAngle / 2) angle = segmentAngle - angle;
-
-            const mirrorX = Math.cos(angle) * radius;
-            const mirrorY = Math.sin(angle) * radius;
-
-            const swirl = noise(mirrorX * 0.05 + seed * 0.00018, mirrorY * 0.05 + seed * 0.00018);
-            const t = (swirl + 1) / 2;
-            const hue = (paletteShift + (angle / segmentAngle) * 360 + radius * 0.22) % 360;
-            const lightness = 40 + 32 * Math.sin(radius * 0.045 + t * Math.PI);
-            const alpha = 0.25 + 0.45 * Math.pow(t, 1.15);
-            ctx.fillStyle = `hsla(${(hue + 360) % 360}, 78%, ${Math.max(32, Math.min(72, lightness))}%, ${alpha})`;
-            ctx.fillRect(x, y, step, step);
-          }
-        }
-        ctx.globalAlpha = 0.55;
-        ctx.strokeStyle = `rgba(${fgColor.r}, ${fgColor.g}, ${fgColor.b}, 0.75)`;
-        ctx.lineWidth = Math.max(1, viewWidth * 0.0014);
-        ctx.beginPath();
-        const reach = Math.max(viewWidth, viewHeight);
-        for (let i = 0; i < 6; i++) {
-          const theta = (i / 6) * Math.PI * 2;
-          ctx.moveTo(centerX, centerY);
-          ctx.lineTo(centerX + Math.cos(theta) * reach, centerY + Math.sin(theta) * reach);
-        }
-        ctx.stroke();
-        ctx.globalAlpha = 1;
-        ctx.restore();
-      }
-
-      function renderGolden(viewWidth, viewHeight, fgColor, scrollShift) {
-        ctx.save();
-        const centerX = viewWidth / 2;
-        const centerY = viewHeight / 2;
-        const phi = (1 + Math.sqrt(5)) / 2;
-        const goldenAngle = Math.PI * (3 - Math.sqrt(5));
-        const rotation = ((seed % 360) * Math.PI) / 180;
-        const offset = ((seed >>> 5) % 97) / 97;
-        const maxRadius = Math.min(viewWidth, viewHeight) * 0.48;
-        const pointCount = 460;
-        const baseHue = (seed % 360 + scrollShift * 240) % 360;
-
-        const glow = ctx.createRadialGradient(
-          centerX,
-          centerY,
-          Math.min(viewWidth, viewHeight) * 0.1,
-          centerX,
-          centerY,
-          Math.max(viewWidth, viewHeight)
-        );
-        glow.addColorStop(0, `rgba(${fgColor.r}, ${fgColor.g}, ${fgColor.b}, 0.22)`);
-        glow.addColorStop(1, 'rgba(0,0,0,0)');
-        ctx.fillStyle = glow;
-        ctx.fillRect(0, 0, viewWidth, viewHeight);
-
-        for (let i = 0; i < pointCount; i++) {
-          const angle = rotation + i * goldenAngle;
-          const radius = Math.sqrt((i + offset) / pointCount) * maxRadius;
-          const px = centerX + Math.cos(angle) * radius;
-          const py = centerY + Math.sin(angle) * radius;
-          const falloff = 1 - radius / maxRadius;
-          const alpha = 0.18 + 0.55 * Math.max(0, falloff);
-          const hue = (baseHue + i * 0.72 + scrollShift * 180) % 360;
-          const lightness = 48 + falloff * 44;
-          const size = 0.9 + falloff * 3.6;
-          ctx.beginPath();
-          ctx.fillStyle = `hsla(${(hue + 360) % 360}, 86%, ${Math.max(38, Math.min(78, lightness))}%, ${alpha})`;
-          ctx.arc(px, py, size, 0, Math.PI * 2);
-          ctx.fill();
-        }
-
-        const trunkWidth = Math.max(1.4, viewWidth * 0.0026);
-        const sway = 0.28 + 0.14 * Math.sin(seed * 0.0003 + scrollShift * Math.PI * 2);
-        const depthLimit = 9;
-        const baseLength = Math.min(viewWidth, viewHeight) / 3.2;
-
-        ctx.lineCap = 'round';
-        ctx.strokeStyle = `rgba(${fgColor.r}, ${fgColor.g}, ${fgColor.b}, 0.55)`;
-        ctx.lineWidth = trunkWidth * 1.08;
-
-        function branch(x, y, length, angle, depth) {
-          if (depth > depthLimit || length < 4) return;
-          const tipX = x + length * Math.cos(angle);
-          const tipY = y - length * Math.sin(angle);
-
-          ctx.beginPath();
-          ctx.moveTo(x, y);
-          ctx.lineTo(tipX, tipY);
-          ctx.stroke();
-
-          const nextLength = length / phi;
-          const accentHue = (baseHue + depth * 22 + scrollShift * 180) % 360;
-          ctx.save();
-          ctx.strokeStyle = `hsla(${accentHue}, 88%, 70%, ${0.28 + Math.max(0, 0.18 * (1 - depth / depthLimit))})`;
-          ctx.lineWidth = Math.max(0.8, trunkWidth * Math.pow(0.78, depth + 1));
-          ctx.beginPath();
-          ctx.moveTo(x, y);
-          ctx.lineTo(tipX, tipY);
-          ctx.stroke();
-          ctx.restore();
-
-          branch(tipX, tipY, nextLength, angle + sway, depth + 1);
-          branch(tipX, tipY, nextLength, angle - sway, depth + 1);
-          if (depth % 2 === 0) {
-            branch(tipX, tipY, nextLength / phi, angle + sway * 0.35, depth + 2);
-          }
-        }
-
-        branch(centerX, viewHeight * 0.92, baseLength, Math.PI / 2, 0);
-        ctx.restore();
-      }
-
-      toggleButton?.addEventListener('click', () => {
-        if (enabled) {
-          disable();
-        } else {
-          enable();
-        }
-      });
-
-      modeButton?.addEventListener('click', () => {
-        const index = FRACTAL_MODES.indexOf(mode);
-        const next = FRACTAL_MODES[(index + 1) % FRACTAL_MODES.length];
-        mode = next;
-        persistMode(next);
-        updateButtons();
-        if (!enabled) {
-          enable();
-        } else {
-          scheduleRender();
-        }
-      });
-
-      shuffleButton?.addEventListener('click', () => {
-        setSeed(randomSeed());
-        if (!enabled) {
-          enable();
-        } else {
-          scheduleRender();
-        }
-      });
-
-      shuffleButton?.setAttribute('aria-label', 'Shuffle fractal seed');
-
-      themeButton?.addEventListener('click', () => {
-        if (enabled) {
-          requestAnimationFrame(() => scheduleRender());
-        }
-      });
-
-      document.addEventListener('visibilitychange', () => {
-        if (enabled && document.visibilityState === 'visible') {
-          scheduleRender();
-        }
-      });
-
-      window.addEventListener('pageshow', event => {
-        if (event.persisted && enabled) {
-          handleResize();
-          scheduleRender();
-        }
-      });
-
-      updateButtons();
-    })();
-
-    // Header surface effect
-    const headerEl = document.querySelector('[data-header]');
-    const backToTopEl = document.querySelector('[data-back-to-top]');
-    const toggleHeaderState = () => {
-      if (headerEl) {
-        const active = window.scrollY > 16;
-        headerEl.classList.toggle('backdrop-blur-xl', active);
-        headerEl.classList.toggle('border-slate-200/70', active);
-        headerEl.classList.toggle('dark:border-slate-800/70', active);
-        headerEl.classList.toggle('bg-white/70', active);
-        headerEl.classList.toggle('dark:bg-slate-950/70', active);
-        headerEl.classList.toggle('shadow-soft', active);
-      }
-
-      if (backToTopEl) {
-        const show = window.scrollY > 360;
-        backToTopEl.classList.toggle('pointer-events-none', !show);
-        backToTopEl.classList.toggle('opacity-0', !show);
-        backToTopEl.classList.toggle('translate-y-4', !show);
-      }
-    };
-    toggleHeaderState();
-    window.addEventListener('scroll', toggleHeaderState, { passive: true });
-
-    // Form submission handling
-    const successClasses = ['text-brand-600', 'dark:text-brand-300'];
-    const errorClasses = ['text-red-600', 'dark:text-red-400'];
-    document.querySelectorAll('form[data-form]').forEach(form => {
-      const statusEl = form.querySelector('[data-form-status]');
-      const submitButton = form.querySelector('button[type="submit"]');
-      if (!statusEl) return;
-
-      form.addEventListener('submit', async event => {
-        event.preventDefault();
-        statusEl.classList.remove('hidden');
-        statusEl.textContent = 'Sending…';
-        statusEl.classList.remove(...errorClasses);
-        statusEl.classList.add(...successClasses);
-        if (submitButton) {
-          submitButton.disabled = true;
-          submitButton.setAttribute('aria-disabled', 'true');
-        }
-
-        try {
-          const formData = new FormData(form);
-          const response = await fetch(form.action, {
-            method: 'POST',
-            body: formData,
-            headers: { Accept: 'application/json' },
-          });
-
-          if (response.ok) {
-            statusEl.textContent = 'Thanks! Your message is on its way.';
-            form.reset();
-          } else {
-            const data = await response.json().catch(() => null);
-            const message = data?.errors?.[0]?.message || data?.message || 'Something went wrong. Please email isaacinpursuit@gmail.com.';
-            statusEl.textContent = message;
-            statusEl.classList.remove(...successClasses);
-            statusEl.classList.add(...errorClasses);
-          }
-        } catch (error) {
-          statusEl.textContent = 'Something went wrong. Please email isaacinpursuit@gmail.com.';
-          statusEl.classList.remove(...successClasses);
-          statusEl.classList.add(...errorClasses);
-        } finally {
-          if (submitButton) {
-            submitButton.disabled = false;
-            submitButton.removeAttribute('aria-disabled');
-          }
-        }
-      });
-    });
-
-    // Year stamp
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
+  <aside id="settings-panel" role="region" aria-label="Demo fine controls">
+    <header>
+      <h2 id="settings-title">Settings</h2>
+      <button id="reset-demo" type="button">Reset</button>
+    </header>
+    <form id="settings-form" autocomplete="off"></form>
+    <label id="explain-toggle">
+      <input type="checkbox" id="explain-checkbox" name="explain" />
+      Explain the math
+    </label>
+  </aside>
+
+  <section id="explain-panel" hidden>
+    <h3 id="explain-title"></h3>
+    <div id="explain-content"></div>
+  </section>
+
+  <noscript>This interactive gallery requires JavaScript to render the mathematical demos.</noscript>
+  <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/js/demos/epicycles.js
+++ b/js/demos/epicycles.js
@@ -1,0 +1,268 @@
+// js/demos/epicycles.js
+// Fourier epicycle decomposition of preloaded SVG paths.
+import {
+  TAU,
+  createSeededRng,
+  pickPalette,
+  getPaletteNames,
+  lerpColor,
+  clamp,
+  setCanvasBackground,
+  generateSeed,
+  createSvgPathParser,
+  createSvgPathSampler,
+  normalizePathPoints,
+} from '../utils.js';
+
+const rawPaths = [
+  {
+    id: 'phi-curve',
+    name: 'Phi Curve',
+    path: 'M 0 -60 L -30 -60 L -30 60 L 0 60 L 0 15 C 15 20 35 10 45 -10 C 55 -30 50 -55 30 -70 C 15 -82 -10 -80 0 -100 L 0 -125 L 45 -125',
+  },
+  {
+    id: 'infinity',
+    name: 'Infinity Loop',
+    path: 'M -60 0 C -60 -40 -20 -40 -10 0 C 0 40 40 40 40 0 C 40 -40 80 -40 80 0 C 80 40 40 40 30 0 C 20 -40 -20 -40 -20 0 C -20 40 -60 40 -60 0 Z',
+  },
+];
+
+function computeDFT(points) {
+  const N = points.length;
+  const coefficients = [];
+  for (let k = 0; k < N; k += 1) {
+    let re = 0;
+    let im = 0;
+    for (let n = 0; n < N; n += 1) {
+      const angle = (TAU * k * n) / N;
+      const cos = Math.cos(angle);
+      const sin = Math.sin(angle);
+      const { x, y } = points[n];
+      re += x * cos + y * sin;
+      im += -x * sin + y * cos;
+    }
+    re /= N;
+    im /= N;
+    const amplitude = Math.hypot(re, im);
+    const phase = Math.atan2(im, re);
+    const freq = k <= N / 2 ? k : k - N;
+    coefficients.push({ re, im, amplitude, phase, freq });
+  }
+  coefficients.sort((a, b) => b.amplitude - a.amplitude);
+  return coefficients;
+}
+
+function preparePathData(raw) {
+  const segments = createSvgPathParser(raw.path);
+  const points = createSvgPathSampler(segments, { samples: 180 });
+  const filtered = points.filter((p, index) => index === 0 || points[index - 1].x !== p.x || points[index - 1].y !== p.y);
+  const normalized = normalizePathPoints(filtered);
+  const coefficients = computeDFT(normalized);
+  return {
+    id: raw.id,
+    name: raw.name,
+    points: normalized,
+    coefficients,
+  };
+}
+
+const preparedPaths = rawPaths.map(preparePathData);
+
+class FourierEpicycles {
+  constructor(env, saved = {}) {
+    this.ctx = env.ctx;
+    this.width = env.width;
+    this.height = env.height;
+    this.calm = Boolean(env.calm);
+
+    this.seed = saved.seed ?? 91011;
+    this.paletteName = saved.palette ?? 'ocean';
+    this.pathId = saved.path ?? preparedPaths[0].id;
+    this.terms = saved.terms ?? (this.calm ? 45 : 90);
+    this.speed = saved.speed ?? (this.calm ? 0.25 : 0.5);
+    this.traceLength = saved.trace ?? 400;
+
+    this.palette = pickPalette(this.paletteName);
+    this.rng = createSeededRng(this.seed);
+
+    this.time = 0;
+    this.trace = [];
+    this.setPath(this.pathId);
+  }
+
+  getSettings() {
+    return [
+      { id: 'seed', label: 'Seed', type: 'integer', min: 1, max: 999999, value: this.seed },
+      {
+        id: 'path',
+        label: 'Path',
+        type: 'select',
+        options: preparedPaths.map((p) => ({ value: p.id, label: p.name })),
+        value: this.pathId,
+      },
+      { id: 'terms', label: 'Fourier Terms', type: 'range', min: 10, max: 180, step: 1, value: this.terms },
+      { id: 'speed', label: 'Speed', type: 'range', min: 0.05, max: 1, step: 0.01, value: this.speed },
+      { id: 'trace', label: 'Trace Length', type: 'range', min: 60, max: 800, step: 10, value: this.traceLength },
+      {
+        id: 'palette',
+        label: 'Palette',
+        type: 'select',
+        options: getPaletteNames().map((name) => ({ value: name, label: name })),
+        value: this.paletteName,
+      },
+    ];
+  }
+
+  updateSetting(id, value) {
+    if (id === 'seed') {
+      this.seed = Math.max(1, Number(value));
+      this.rng = createSeededRng(this.seed);
+    } else if (id === 'path') {
+      this.setPath(value);
+    } else if (id === 'terms') {
+      this.terms = Math.round(value);
+    } else if (id === 'speed') {
+      this.speed = Number(value);
+    } else if (id === 'trace') {
+      this.traceLength = Math.round(value);
+    } else if (id === 'palette') {
+      this.paletteName = value;
+      this.palette = pickPalette(value);
+    }
+  }
+
+  reset() {
+    this.seed = generateSeed();
+    this.rng = createSeededRng(this.seed);
+    this.trace = [];
+  }
+
+  setCalmMode(enabled) {
+    this.calm = enabled;
+    this.terms = enabled ? Math.min(this.terms, 60) : Math.max(this.terms, 90);
+    this.speed = enabled ? Math.min(this.speed, 0.35) : Math.max(this.speed, 0.5);
+  }
+
+  resize({ width, height }) {
+    this.width = width;
+    this.height = height;
+  }
+
+  setPath(id) {
+    const data = preparedPaths.find((path) => path.id === id) || preparedPaths[0];
+    this.pathId = data.id;
+    this.pathData = data;
+    this.trace = [];
+  }
+
+  handleScroll({ deltaY }) {
+    const direction = Math.sign(deltaY);
+    this.terms = clamp(this.terms + direction * -3, 10, 240);
+    return true;
+  }
+
+  update(dt) {
+    const timeScale = this.speed * (this.calm ? 0.6 : 1);
+    this.time = (this.time + dt * timeScale) % 1;
+    const t = this.time;
+    const center = { x: 0, y: 0 };
+    const contributions = [];
+    const maxTerms = Math.min(this.terms, this.pathData.coefficients.length);
+    let x = center.x;
+    let y = center.y;
+
+    for (let i = 0; i < maxTerms; i += 1) {
+      const coeff = this.pathData.coefficients[i];
+      const angle = TAU * coeff.freq * t + coeff.phase;
+      const dx = coeff.amplitude * Math.cos(angle);
+      const dy = coeff.amplitude * Math.sin(angle);
+      contributions.push({ x, y, radius: coeff.amplitude, dx, dy });
+      x += dx;
+      y += dy;
+    }
+
+    this.current = { x, y, contributions };
+    this.trace.push({ x, y });
+    if (this.trace.length > this.traceLength) {
+      this.trace.shift();
+    }
+  }
+
+  render(ctx) {
+    setCanvasBackground(ctx, this.width, this.height, '#05050b');
+    ctx.save();
+    ctx.translate(this.width / 2, this.height / 2);
+    const scale = Math.min(this.width, this.height) * 0.38;
+
+    if (this.current) {
+      ctx.save();
+      ctx.globalAlpha = 0.45;
+      this.current.contributions.forEach((circle, index) => {
+        if (circle.radius === 0) return;
+        ctx.beginPath();
+        ctx.strokeStyle = 'rgba(255,255,255,0.15)';
+        ctx.lineWidth = 1;
+        ctx.arc(circle.x * scale, circle.y * scale, Math.abs(circle.radius) * scale, 0, TAU);
+        ctx.stroke();
+
+        const endX = (circle.x + circle.dx) * scale;
+        const endY = (circle.y + circle.dy) * scale;
+        ctx.beginPath();
+        const color = this.palette[index % this.palette.length];
+        ctx.strokeStyle = color;
+        ctx.moveTo(circle.x * scale, circle.y * scale);
+        ctx.lineTo(endX, endY);
+        ctx.stroke();
+      });
+      ctx.restore();
+
+      ctx.save();
+      ctx.globalAlpha = 0.9;
+      ctx.fillStyle = '#ffffff';
+      ctx.beginPath();
+      ctx.arc(this.current.x * scale, this.current.y * scale, this.calm ? 1.8 : 2.5, 0, TAU);
+      ctx.fill();
+      ctx.restore();
+    }
+
+    if (this.trace.length > 1) {
+      ctx.save();
+      ctx.lineWidth = this.calm ? 1.2 : 1.6;
+      ctx.lineJoin = 'round';
+      ctx.lineCap = 'round';
+      for (let i = 1; i < this.trace.length; i += 1) {
+        const prev = this.trace[i - 1];
+        const curr = this.trace[i];
+        const t = i / (this.trace.length - 1);
+        const colorIndex = t * (this.palette.length - 1);
+        const base = Math.floor(colorIndex);
+        const next = Math.min(this.palette.length - 1, base + 1);
+        const c = lerpColor(this.palette[base], this.palette[next], colorIndex - base);
+        ctx.strokeStyle = c;
+        ctx.beginPath();
+        ctx.moveTo(prev.x * scale, prev.y * scale);
+        ctx.lineTo(curr.x * scale, curr.y * scale);
+        ctx.stroke();
+      }
+      ctx.restore();
+    }
+
+    ctx.restore();
+
+    ctx.save();
+    ctx.fillStyle = '#ffffffcc';
+    ctx.font = '600 13px "Inter", system-ui';
+    ctx.textAlign = 'left';
+    ctx.fillText(`${this.pathData.name} – ${this.terms} terms`, 24, this.height - 32);
+    ctx.restore();
+  }
+}
+
+const explain = `The SVG path is sampled into complex points z_n. We compute the discrete Fourier transform X_k = (1/N) Σ z_n e^{-i2πkn/N} and draw epicycles for each harmonic sorted by amplitude. The vector sum traces the original curve as t sweeps around [0, 1).`;
+
+export default {
+  id: 'epicycles',
+  name: 'Fourier Epicycles',
+  explain,
+  create: (env, saved) => new FourierEpicycles(env, saved),
+};

--- a/js/demos/flowfield.js
+++ b/js/demos/flowfield.js
@@ -1,0 +1,183 @@
+// js/demos/flowfield.js
+// Particle advection through a Perlin noise flow field.
+import {
+  setCanvasBackground,
+  clamp,
+  seededNoise2D,
+  createSeededRng,
+  pickPalette,
+  getPaletteNames,
+  generateSeed,
+} from '../utils.js';
+
+class FlowFieldDemo {
+  constructor(env, saved = {}) {
+    this.ctx = env.ctx;
+    this.width = env.width;
+    this.height = env.height;
+    this.calm = Boolean(env.calm);
+
+    this.seed = saved.seed ?? 13579;
+    this.noiseScale = saved.noiseScale ?? 0.0016;
+    this.speed = saved.speed ?? (this.calm ? 30 : 45);
+    this.particleCount = saved.count ?? (this.calm ? 600 : 1200);
+    this.paletteName = saved.palette ?? 'aurora';
+
+    this.palette = pickPalette(this.paletteName);
+    this.rng = createSeededRng(this.seed);
+    this.noise = seededNoise2D(this.seed, 1);
+
+    this.particles = [];
+    this.pointer = { x: this.width / 2, y: this.height / 2, active: false };
+    this.offset = { x: 0, y: 0 };
+
+    this.initParticles();
+  }
+
+  getSettings() {
+    return [
+      { id: 'seed', label: 'Seed', type: 'integer', min: 1, max: 999999, value: this.seed },
+      { id: 'noiseScale', label: 'Noise Scale', type: 'range', min: 0.0005, max: 0.004, step: 0.0001, value: this.noiseScale },
+      { id: 'speed', label: 'Particle Speed', type: 'range', min: 10, max: 90, step: 1, value: this.speed },
+      { id: 'count', label: 'Particles', type: 'range', min: 200, max: 2000, step: 50, value: this.particleCount },
+      {
+        id: 'palette',
+        label: 'Palette',
+        type: 'select',
+        options: getPaletteNames().map((name) => ({ value: name, label: name })),
+        value: this.paletteName,
+      },
+    ];
+  }
+
+  updateSetting(id, value) {
+    if (id === 'seed') {
+      this.seed = Math.max(1, Number(value));
+      this.rng = createSeededRng(this.seed);
+      this.noise = seededNoise2D(this.seed, 1);
+      this.initParticles();
+    } else if (id === 'noiseScale') {
+      this.noiseScale = Number(value);
+    } else if (id === 'speed') {
+      this.speed = Number(value);
+    } else if (id === 'count') {
+      this.particleCount = Math.round(value);
+      this.initParticles();
+    } else if (id === 'palette') {
+      this.paletteName = value;
+      this.palette = pickPalette(value);
+    }
+  }
+
+  reset() {
+    this.seed = generateSeed();
+    this.rng = createSeededRng(this.seed);
+    this.noise = seededNoise2D(this.seed, 1);
+    this.initParticles();
+  }
+
+  setCalmMode(enabled) {
+    this.calm = enabled;
+    this.particleCount = enabled ? Math.min(this.particleCount, 800) : Math.max(this.particleCount, 1200);
+    this.speed = enabled ? Math.min(this.speed, 35) : Math.max(this.speed, 45);
+    this.initParticles();
+  }
+
+  resize({ width, height }) {
+    this.width = width;
+    this.height = height;
+    this.initParticles();
+  }
+
+  initParticles() {
+    this.particles = [];
+    for (let i = 0; i < this.particleCount; i += 1) {
+      this.particles.push({
+        x: this.rng() * this.width,
+        y: this.rng() * this.height,
+        life: this.rng() * 200,
+        color: this.palette[i % this.palette.length],
+      });
+    }
+  }
+
+  handleScroll({ deltaY, ctrlKey }) {
+    if (ctrlKey) {
+      const factor = Math.exp(-deltaY * 0.0012);
+      this.noiseScale = clamp(this.noiseScale * factor, 0.0004, 0.006);
+    } else {
+      this.speed = clamp(this.speed + Math.sign(deltaY) * -3, 10, 100);
+    }
+    return true;
+  }
+
+  pointerDown(event) {
+    this.pointer = { x: event.clientX, y: event.clientY, active: true };
+  }
+
+  pointerDrag(event) {
+    this.pointer = { x: event.clientX, y: event.clientY, active: true };
+  }
+
+  pointerUp() {
+    this.pointer.active = false;
+  }
+
+  update(dt) {
+    const velocity = this.speed * dt;
+    const influenceRadius = this.calm ? 120 : 200;
+
+    for (const particle of this.particles) {
+      const nx = (particle.x + this.offset.x) * this.noiseScale;
+      const ny = (particle.y + this.offset.y) * this.noiseScale;
+      const angle = this.noise(nx, ny) * Math.PI * 2;
+      const vx = Math.cos(angle) * velocity;
+      const vy = Math.sin(angle) * velocity;
+      particle.x += vx;
+      particle.y += vy;
+      particle.life -= dt * 60;
+
+      if (this.pointer.active) {
+        const dx = this.pointer.x - particle.x;
+        const dy = this.pointer.y - particle.y;
+        const distSq = dx * dx + dy * dy;
+        if (distSq < influenceRadius * influenceRadius) {
+          particle.x -= dx * 0.002;
+          particle.y -= dy * 0.002;
+        }
+      }
+
+      if (particle.x < -20 || particle.x > this.width + 20 || particle.y < -20 || particle.y > this.height + 20 || particle.life <= 0) {
+        particle.x = this.rng() * this.width;
+        particle.y = this.rng() * this.height;
+        particle.life = 200 + this.rng() * 200;
+      }
+    }
+  }
+
+  render(ctx) {
+    setCanvasBackground(ctx, this.width, this.height, 'rgba(2,3,6,0.16)');
+    ctx.save();
+    ctx.globalCompositeOperation = 'lighter';
+    ctx.lineWidth = 1.2;
+
+    for (const particle of this.particles) {
+      ctx.strokeStyle = particle.color;
+      ctx.beginPath();
+      ctx.moveTo(particle.x, particle.y);
+      ctx.lineTo(particle.x - 2, particle.y - 2);
+      ctx.stroke();
+    }
+
+    ctx.restore();
+  }
+}
+
+const explain = 'The flow field samples Perlin noise to build a continuously varying vector field. Particles advect along the curl-like streaks, a common technique for visualizing divergence-free fields and fluid motion. Calm mode reduces particle count and drift speed.';
+
+export default {
+  id: 'flowfield',
+  name: 'Perlin Flow Field',
+  explain,
+  create: (env, saved) => new FlowFieldDemo(env, saved),
+};

--- a/js/demos/golden-grid.js
+++ b/js/demos/golden-grid.js
@@ -1,0 +1,150 @@
+// js/demos/golden-grid.js
+// Golden ratio grid with logarithmic spiral overlay.
+import {
+  PHI,
+  setCanvasBackground,
+  goldenSpiralPoint,
+  pickPalette,
+  getPaletteNames,
+} from '../utils.js';
+
+class GoldenGridDemo {
+  constructor(env, saved = {}) {
+    this.ctx = env.ctx;
+    this.width = env.width;
+    this.height = env.height;
+    this.calm = Boolean(env.calm);
+
+    this.scale = saved.scale ?? 0.8;
+    this.rotation = saved.rotation ?? 0;
+    this.sections = saved.sections ?? 6;
+    this.paletteName = saved.palette ?? 'sunflower';
+    this.showLabels = saved.labels ?? true;
+
+    this.palette = pickPalette(this.paletteName);
+  }
+
+  getSettings() {
+    return [
+      { id: 'scale', label: 'Grid scale', type: 'range', min: 0.4, max: 1, step: 0.02, value: this.scale },
+      { id: 'rotation', label: 'Rotation', type: 'range', min: -Math.PI, max: Math.PI, step: 0.01, value: this.rotation },
+      { id: 'sections', label: 'Spiral turns', type: 'range', min: 3, max: 10, step: 1, value: this.sections },
+      { id: 'labels', label: 'Show guide labels', type: 'checkbox', value: this.showLabels },
+      {
+        id: 'palette',
+        label: 'Palette',
+        type: 'select',
+        options: getPaletteNames().map((name) => ({ value: name, label: name })),
+        value: this.paletteName,
+      },
+    ];
+  }
+
+  updateSetting(id, value) {
+    if (id === 'scale') {
+      this.scale = Number(value);
+    } else if (id === 'rotation') {
+      this.rotation = Number(value);
+    } else if (id === 'sections') {
+      this.sections = Math.round(value);
+    } else if (id === 'labels') {
+      this.showLabels = Boolean(value);
+    } else if (id === 'palette') {
+      this.paletteName = value;
+      this.palette = pickPalette(value);
+    }
+  }
+
+  reset() {
+    this.rotation = 0;
+  }
+
+  setCalmMode(enabled) {
+    this.calm = enabled;
+    this.sections = enabled ? Math.min(this.sections, 5) : Math.max(this.sections, 7);
+  }
+
+  resize({ width, height }) {
+    this.width = width;
+    this.height = height;
+  }
+
+  handleScroll({ deltaY }) {
+    this.rotation += Math.sign(deltaY) * 0.05;
+    return true;
+  }
+
+  update() {}
+
+  render(ctx) {
+    setCanvasBackground(ctx, this.width, this.height, '#030508');
+    ctx.save();
+    ctx.translate(this.width / 2, this.height / 2);
+    ctx.rotate(this.rotation);
+    ctx.scale(this.scale, this.scale);
+
+    const palette = this.palette;
+    const rectColor = palette[0];
+    const lineColor = palette[2] || '#ffffff';
+
+    // Draw golden rectangles recursively.
+    const size = Math.min(this.width, this.height) * 0.5;
+    this.drawGoldenRectangles(ctx, -size / 2, -size / 2, size, 0, 6, rectColor, lineColor);
+
+    // Draw logarithmic spiral: r = a e^{bθ} with b = ln φ / (π/2)
+    const b = Math.log(PHI) / (Math.PI / 2);
+    const a = size * 0.18;
+    const turns = this.sections;
+
+    ctx.strokeStyle = palette[palette.length - 1];
+    ctx.lineWidth = this.calm ? 1 : 1.6;
+    ctx.beginPath();
+    for (let i = 0; i <= turns * 90; i += 1) {
+      const theta = (i / 90) * (Math.PI / 2);
+      const point = goldenSpiralPoint(a, b, theta);
+      if (i === 0) ctx.moveTo(point.x, point.y);
+      else ctx.lineTo(point.x, point.y);
+    }
+    ctx.stroke();
+
+    ctx.restore();
+
+    if (this.showLabels) {
+      ctx.save();
+      ctx.fillStyle = '#ffffffaa';
+      ctx.font = '600 14px "Inter", system-ui';
+      ctx.textAlign = 'left';
+      ctx.fillText(`φ ≈ ${PHI.toFixed(5)}`, 24, this.height - 56);
+      ctx.fillText('Log spiral r = a e^{bθ}', 24, this.height - 36);
+      ctx.restore();
+    }
+  }
+
+  drawGoldenRectangles(ctx, x, y, size, rotation, depth, fillColor, lineColor) {
+    if (depth === 0) return;
+    ctx.save();
+    ctx.translate(x + size / 2, y + size / 2);
+    ctx.rotate(rotation);
+    ctx.translate(-size / 2, -size / 2);
+    ctx.fillStyle = fillColor.replace('rgb', 'rgba').replace(')', ', 0.08)');
+    ctx.fillRect(0, 0, size, size / PHI);
+    ctx.strokeStyle = lineColor;
+    ctx.lineWidth = 0.8;
+    ctx.strokeRect(0, 0, size, size / PHI);
+    ctx.restore();
+
+    const nextSize = size / PHI;
+    const nextX = x + size - nextSize;
+    const nextY = y;
+    this.drawGoldenRectangles(ctx, nextX, nextY, nextSize, rotation - Math.PI / 2, depth - 1, fillColor, lineColor);
+  }
+}
+
+const explain = 'The golden ratio φ splits a segment so that whole-to-large equals large-to-small. Repeated subdivision of a square produces the classical golden rectangle grid. Connecting the quarter-circle arcs yields a logarithmic spiral with constant angle to the radial lines.';
+
+export default {
+  id: 'golden-grid',
+  name: 'Golden Ratio Grid',
+  explain,
+  create: (env, saved) => new GoldenGridDemo(env, saved),
+};

--- a/js/demos/hilbert.js
+++ b/js/demos/hilbert.js
@@ -1,0 +1,188 @@
+// js/demos/hilbert.js
+// Hilbert space-filling curve traced progressively.
+import {
+  pickPalette,
+  getPaletteNames,
+  setCanvasBackground,
+  clamp,
+  lerpColor,
+  createSeededRng,
+  generateSeed,
+} from '../utils.js';
+
+function rotate(n, x, y, rx, ry) {
+  if (ry === 0) {
+    if (rx === 1) {
+      x = n - 1 - x;
+      y = n - 1 - y;
+    }
+    const temp = x;
+    x = y;
+    y = temp;
+  }
+  return { x, y };
+}
+
+function hilbertPoints(order) {
+  const n = 1 << order;
+  const total = n * n;
+  const points = new Array(total);
+  for (let index = 0; index < total; index += 1) {
+    let x = 0;
+    let y = 0;
+    let t = index;
+    for (let s = 1; s < n; s <<= 1) {
+      const rx = 1 & (t >> 1);
+      const ry = 1 & (t ^ rx);
+      ({ x, y } = rotate(s, x, y, rx, ry));
+      x += s * rx;
+      y += s * ry;
+      t >>= 2;
+    }
+    points[index] = { x, y };
+  }
+  return points;
+}
+
+class HilbertCurveDemo {
+  constructor(env, saved = {}) {
+    this.ctx = env.ctx;
+    this.width = env.width;
+    this.height = env.height;
+    this.calm = Boolean(env.calm);
+
+    this.seed = saved.seed ?? 24680;
+    this.order = saved.order ?? (this.calm ? 4 : 6);
+    this.speed = saved.speed ?? (this.calm ? 0.45 : 0.8);
+    this.paletteName = saved.palette ?? 'sunflower';
+
+    this.palette = pickPalette(this.paletteName);
+    this.rng = createSeededRng(this.seed);
+
+    this.progress = 0;
+    this.points = [];
+    this.computePoints();
+  }
+
+  getSettings() {
+    return [
+      { id: 'seed', label: 'Seed', type: 'integer', min: 1, max: 999999, value: this.seed },
+      { id: 'order', label: 'Order', type: 'range', min: 1, max: 8, step: 1, value: this.order },
+      { id: 'speed', label: 'Trace Speed', type: 'range', min: 0.1, max: 2, step: 0.05, value: this.speed },
+      {
+        id: 'palette',
+        label: 'Palette',
+        type: 'select',
+        options: getPaletteNames().map((name) => ({ value: name, label: name })),
+        value: this.paletteName,
+      },
+    ];
+  }
+
+  updateSetting(id, value) {
+    if (id === 'seed') {
+      this.seed = Math.max(1, Number(value));
+      this.rng = createSeededRng(this.seed);
+    } else if (id === 'order') {
+      this.order = clamp(Math.round(value), 1, 9);
+      this.computePoints();
+    } else if (id === 'speed') {
+      this.speed = Number(value);
+    } else if (id === 'palette') {
+      this.paletteName = value;
+      this.palette = pickPalette(value);
+    }
+  }
+
+  reset() {
+    this.seed = generateSeed();
+    this.rng = createSeededRng(this.seed);
+    this.progress = 0;
+  }
+
+  setCalmMode(enabled) {
+    this.calm = enabled;
+    this.order = enabled ? Math.min(this.order, 5) : Math.max(this.order, 6);
+    this.speed = enabled ? Math.min(this.speed, 0.6) : Math.max(this.speed, 0.8);
+    this.computePoints();
+  }
+
+  resize({ width, height }) {
+    this.width = width;
+    this.height = height;
+  }
+
+  computePoints() {
+    this.points = hilbertPoints(this.order);
+    this.progress = 0;
+  }
+
+  handleScroll({ deltaY }) {
+    const direction = Math.sign(deltaY);
+    this.order = clamp(this.order + direction * -1, 1, 9);
+    this.computePoints();
+    return true;
+  }
+
+  update(dt) {
+    const totalSegments = this.points.length - 1;
+    if (totalSegments <= 0) return;
+    this.progress = (this.progress + dt * this.speed) % totalSegments;
+  }
+
+  render(ctx) {
+    setCanvasBackground(ctx, this.width, this.height, '#030712');
+    if (this.points.length < 2) return;
+
+    const padding = Math.min(this.width, this.height) * 0.1;
+    const scale = (Math.min(this.width, this.height) - padding * 2) / ((1 << this.order) - 1);
+    const offsetX = (this.width - scale * ((1 << this.order) - 1)) / 2;
+    const offsetY = (this.height - scale * ((1 << this.order) - 1)) / 2;
+
+    ctx.save();
+    ctx.lineWidth = this.calm ? 1 : 1.6;
+    ctx.lineCap = 'round';
+
+    const total = this.points.length - 1;
+    const palette = this.palette;
+
+    for (let i = 0; i < total; i += 1) {
+      const start = this.points[i];
+      const end = this.points[i + 1];
+      const sx = offsetX + start.x * scale;
+      const sy = offsetY + start.y * scale;
+      const ex = offsetX + end.x * scale;
+      const ey = offsetY + end.y * scale;
+      const t = i / total;
+      const colorIndex = t * (palette.length - 1);
+      const base = Math.floor(colorIndex);
+      const next = Math.min(palette.length - 1, base + 1);
+      const stroke = lerpColor(palette[base], palette[next], colorIndex - base);
+
+      const opacity = i <= this.progress ? 0.9 : 0.15;
+      ctx.strokeStyle = `${stroke.replace('rgb', 'rgba').replace(')', `, ${opacity})`)}`;
+      ctx.beginPath();
+      ctx.moveTo(sx, sy);
+      ctx.lineTo(ex, ey);
+      ctx.stroke();
+    }
+
+    ctx.restore();
+
+    ctx.save();
+    ctx.fillStyle = '#ffffffcc';
+    ctx.font = '600 14px "Inter", system-ui';
+    ctx.textAlign = 'left';
+    ctx.fillText(`Order ${this.order}`, 24, this.height - 28);
+    ctx.restore();
+  }
+}
+
+const explain = 'Hilbert curves map a 1D line onto a 2D grid through recursive rotations. Each order doubles the resolution while keeping the path continuous, making Hilbert curves useful for locality-preserving spatial indexing.';
+
+export default {
+  id: 'hilbert',
+  name: 'Hilbert Curve',
+  explain,
+  create: (env, saved) => new HilbertCurveDemo(env, saved),
+};

--- a/js/demos/koch.js
+++ b/js/demos/koch.js
@@ -1,0 +1,201 @@
+// js/demos/koch.js
+// Koch snowflake with adjustable iteration level.
+import {
+  pickPalette,
+  getPaletteNames,
+  setCanvasBackground,
+  clamp,
+  lerpColor,
+  createSeededRng,
+  generateSeed,
+} from '../utils.js';
+
+function subdivideSegment(a, b) {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const oneThird = { x: a.x + dx / 3, y: a.y + dy / 3 };
+  const twoThird = { x: a.x + (2 * dx) / 3, y: a.y + (2 * dy) / 3 };
+  const length = Math.sqrt(dx * dx + dy * dy) / 3;
+  const angle = Math.atan2(dy, dx) - Math.PI / 3;
+  const peak = { x: oneThird.x + Math.cos(angle) * length, y: oneThird.y + Math.sin(angle) * length };
+  return [a, oneThird, peak, twoThird];
+}
+
+function generateSnowflake(level) {
+  const initial = [
+    { x: 0, y: -1 },
+    { x: Math.sin(Math.PI / 3), y: 0.5 },
+    { x: -Math.sin(Math.PI / 3), y: 0.5 },
+  ];
+  let points = [...initial, initial[0]];
+  for (let iteration = 0; iteration < level; iteration += 1) {
+    const next = [];
+    for (let i = 0; i < points.length - 1; i += 1) {
+      const segment = subdivideSegment(points[i], points[i + 1]);
+      next.push(...segment);
+    }
+    next.push(points[points.length - 1]);
+    points = next;
+  }
+  return points;
+}
+
+class KochSnowflake {
+  constructor(env, saved = {}) {
+    this.ctx = env.ctx;
+    this.width = env.width;
+    this.height = env.height;
+    this.calm = Boolean(env.calm);
+
+    this.seed = saved.seed ?? 98765;
+    this.level = saved.level ?? (this.calm ? 3 : 4);
+    this.speed = saved.speed ?? (this.calm ? 0.4 : 0.7);
+    this.filled = saved.filled ?? false;
+    this.paletteName = saved.palette ?? 'aurora';
+
+    this.palette = pickPalette(this.paletteName);
+    this.rng = createSeededRng(this.seed);
+
+    this.points = [];
+    this.progress = 0;
+    this.computePoints();
+  }
+
+  getSettings() {
+    return [
+      { id: 'seed', label: 'Seed', type: 'integer', min: 1, max: 999999, value: this.seed },
+      { id: 'level', label: 'Iteration Level', type: 'range', min: 0, max: 6, step: 1, value: this.level },
+      { id: 'speed', label: 'Trace Speed', type: 'range', min: 0.1, max: 2, step: 0.05, value: this.speed },
+      { id: 'filled', label: 'Filled interior', type: 'checkbox', value: this.filled },
+      {
+        id: 'palette',
+        label: 'Palette',
+        type: 'select',
+        options: getPaletteNames().map((name) => ({ value: name, label: name })),
+        value: this.paletteName,
+      },
+    ];
+  }
+
+  updateSetting(id, value) {
+    if (id === 'seed') {
+      this.seed = Math.max(1, Number(value));
+      this.rng = createSeededRng(this.seed);
+    } else if (id === 'level') {
+      this.level = clamp(Math.round(value), 0, 7);
+      this.computePoints();
+    } else if (id === 'speed') {
+      this.speed = Number(value);
+    } else if (id === 'filled') {
+      this.filled = Boolean(value);
+    } else if (id === 'palette') {
+      this.paletteName = value;
+      this.palette = pickPalette(value);
+    }
+  }
+
+  reset() {
+    this.seed = generateSeed();
+    this.rng = createSeededRng(this.seed);
+    this.progress = 0;
+  }
+
+  setCalmMode(enabled) {
+    this.calm = enabled;
+    this.level = enabled ? Math.min(this.level, 3) : Math.max(this.level, 4);
+    this.speed = enabled ? Math.min(this.speed, 0.55) : Math.max(this.speed, 0.7);
+    this.computePoints();
+  }
+
+  resize({ width, height }) {
+    this.width = width;
+    this.height = height;
+  }
+
+  computePoints() {
+    this.points = generateSnowflake(this.level);
+    this.progress = 0;
+  }
+
+  handleScroll({ deltaY }) {
+    const direction = Math.sign(deltaY);
+    this.level = clamp(this.level + direction * -1, 0, 7);
+    this.computePoints();
+    return true;
+  }
+
+  update(dt) {
+    const total = this.points.length - 1;
+    if (total <= 0) return;
+    this.progress = (this.progress + dt * this.speed) % total;
+  }
+
+  render(ctx) {
+    setCanvasBackground(ctx, this.width, this.height, '#060914');
+    if (this.points.length < 2) return;
+
+    const scale = Math.min(this.width, this.height) * 0.42;
+    const centerX = this.width / 2;
+    const centerY = this.height / 2 + scale * 0.1;
+
+    ctx.save();
+    ctx.lineWidth = this.calm ? 1 : 1.4;
+    ctx.lineJoin = 'round';
+    ctx.lineCap = 'round';
+
+    const path = new Path2D();
+    this.points.forEach((point, index) => {
+      const x = centerX + point.x * scale;
+      const y = centerY + point.y * scale;
+      if (index === 0) path.moveTo(x, y);
+      else path.lineTo(x, y);
+    });
+
+    if (this.filled) {
+      ctx.globalAlpha = 0.25;
+      const fillColor = this.palette[0];
+      ctx.fillStyle = fillColor;
+      ctx.fill(path);
+      ctx.globalAlpha = 1;
+    }
+
+    const total = this.points.length - 1;
+    for (let i = 0; i < total; i += 1) {
+      const start = this.points[i];
+      const end = this.points[i + 1];
+      const x1 = centerX + start.x * scale;
+      const y1 = centerY + start.y * scale;
+      const x2 = centerX + end.x * scale;
+      const y2 = centerY + end.y * scale;
+      const t = i / total;
+      const colorIndex = t * (this.palette.length - 1);
+      const base = Math.floor(colorIndex);
+      const next = Math.min(this.palette.length - 1, base + 1);
+      const stroke = lerpColor(this.palette[base], this.palette[next], colorIndex - base);
+      ctx.strokeStyle = stroke;
+      ctx.globalAlpha = i <= this.progress ? 0.95 : 0.18;
+      ctx.beginPath();
+      ctx.moveTo(x1, y1);
+      ctx.lineTo(x2, y2);
+      ctx.stroke();
+    }
+
+    ctx.restore();
+
+    ctx.save();
+    ctx.fillStyle = '#ffffffcc';
+    ctx.font = '600 14px "Inter", system-ui';
+    ctx.textAlign = 'right';
+    ctx.fillText(`Level ${this.level}`, this.width - 24, this.height - 30);
+    ctx.restore();
+  }
+}
+
+const explain = 'Each iteration of the Koch construction replaces a segment with four edges that form an equilateral bump. The number of edges grows by a factor of four per level while the snowflake perimeter diverges; its area converges to 8/5 of the starting triangle.';
+
+export default {
+  id: 'koch',
+  name: 'Koch Snowflake',
+  explain,
+  create: (env, saved) => new KochSnowflake(env, saved),
+};

--- a/js/demos/lissajous.js
+++ b/js/demos/lissajous.js
@@ -1,0 +1,191 @@
+// js/demos/lissajous.js
+// Combined Lissajous figure and damped harmonograph curves.
+import {
+  TAU,
+  createSeededRng,
+  pickPalette,
+  getPaletteNames,
+  lerpColor,
+  clamp,
+  setCanvasBackground,
+  generateSeed,
+} from '../utils.js';
+
+const ratioPresets = [
+  '1:2',
+  '2:3',
+  '3:4',
+  '3:5',
+  '4:5',
+  '5:7',
+  '5:8',
+];
+
+class LissajousHarmonograph {
+  constructor(env, saved = {}) {
+    this.ctx = env.ctx;
+    this.width = env.width;
+    this.height = env.height;
+    this.calm = Boolean(env.calm);
+
+    this.seed = saved.seed ?? 77777;
+    this.paletteName = saved.palette ?? 'twilight';
+    this.ratio = saved.ratio ?? '3:4';
+    this.phase = saved.phase ?? TAU / 4;
+    this.damping = saved.damping ?? 0.015;
+    this.speed = saved.speed ?? (this.calm ? 0.25 : 0.45);
+
+    this.rng = createSeededRng(this.seed);
+    this.palette = pickPalette(this.paletteName);
+
+    this.time = 0;
+    this.samples = this.calm ? 500 : 1000;
+    this.secondPhase = this.rng() * TAU;
+    this.harmonicPhase = this.rng() * TAU;
+  }
+
+  getSettings() {
+    return [
+      { id: 'seed', label: 'Seed', type: 'integer', min: 1, max: 999999, value: this.seed },
+      {
+        id: 'ratio',
+        label: 'Frequency Ratio',
+        type: 'select',
+        options: ratioPresets.map((r) => ({ value: r, label: r })),
+        value: this.ratio,
+      },
+      { id: 'phase', label: 'Phase Offset', type: 'range', min: 0, max: TAU, step: 0.01, value: this.phase },
+      { id: 'damping', label: 'Damping', type: 'range', min: 0.001, max: 0.05, step: 0.001, value: this.damping },
+      { id: 'speed', label: 'Speed', type: 'range', min: 0.05, max: 1, step: 0.01, value: this.speed },
+      {
+        id: 'palette',
+        label: 'Palette',
+        type: 'select',
+        options: getPaletteNames().map((name) => ({ value: name, label: name })),
+        value: this.paletteName,
+      },
+    ];
+  }
+
+  updateSetting(id, value) {
+    if (id === 'seed') {
+      this.seed = Math.max(1, Number(value));
+      this.rng = createSeededRng(this.seed);
+      this.secondPhase = this.rng() * TAU;
+      this.harmonicPhase = this.rng() * TAU;
+    } else if (id === 'ratio') {
+      this.ratio = value;
+    } else if (id === 'phase') {
+      this.phase = Number(value);
+    } else if (id === 'damping') {
+      this.damping = Number(value);
+    } else if (id === 'speed') {
+      this.speed = Number(value);
+    } else if (id === 'palette') {
+      this.paletteName = value;
+      this.palette = pickPalette(value);
+    }
+  }
+
+  reset() {
+    this.seed = generateSeed();
+    this.rng = createSeededRng(this.seed);
+    this.secondPhase = this.rng() * TAU;
+    this.harmonicPhase = this.rng() * TAU;
+  }
+
+  setCalmMode(enabled) {
+    this.calm = enabled;
+    this.samples = enabled ? 420 : 1000;
+    this.speed = enabled ? Math.min(this.speed, 0.3) : Math.max(this.speed, 0.45);
+  }
+
+  resize({ width, height }) {
+    this.width = width;
+    this.height = height;
+  }
+
+  handleScroll({ deltaY }) {
+    const direction = Math.sign(deltaY);
+    this.phase = clamp(this.phase + direction * -0.08, 0, TAU);
+    return true;
+  }
+
+  parseRatio() {
+    const [aStr, bStr] = this.ratio.split(':');
+    const a = parseInt(aStr, 10) || 1;
+    const b = parseInt(bStr, 10) || 1;
+    return { a, b };
+  }
+
+  samplePoint(t) {
+    const { a, b } = this.parseRatio();
+    const amplitude = Math.min(this.width, this.height) * 0.35;
+    const damping = this.damping;
+    const time = t * TAU;
+    // Lissajous term: orthogonal sine oscillations with optional phase offset.
+    const xPrimary = Math.sin(a * time + this.phase);
+    const yPrimary = Math.sin(b * time);
+
+    // Harmonograph term: secondary oscillation with exponential damping.
+    const xHarm = Math.sin((a + 1) * time + this.secondPhase) * Math.exp(-damping * 1.2 * time);
+    const yHarm = Math.sin((b + 2) * time + this.harmonicPhase) * Math.exp(-damping * 1.4 * time);
+
+    const x = (xPrimary + 0.35 * xHarm) * amplitude * Math.exp(-damping * time);
+    const y = (yPrimary + 0.4 * yHarm) * amplitude * Math.exp(-damping * 0.9 * time);
+    return { x: this.width / 2 + x, y: this.height / 2 + y };
+  }
+
+  update(dt) {
+    this.time += dt * this.speed;
+    this.phase = (this.phase + dt * this.speed * 0.2) % TAU;
+  }
+
+  render(ctx) {
+    setCanvasBackground(ctx, this.width, this.height, '#04040a');
+    ctx.save();
+    ctx.lineWidth = this.calm ? 0.8 : 1.2;
+    ctx.lineCap = 'round';
+
+    let previous = null;
+    const steps = this.samples;
+    const palette = this.palette;
+
+    for (let i = 0; i <= steps; i += 1) {
+      const t = i / steps;
+      const point = this.samplePoint(t + this.time * 0.05);
+      if (previous) {
+        const colorIndex = (i / steps) * (palette.length - 1);
+        const baseIndex = Math.floor(colorIndex);
+        const nextIndex = Math.min(palette.length - 1, baseIndex + 1);
+        const localT = colorIndex - baseIndex;
+        const stroke = lerpColor(palette[baseIndex], palette[nextIndex], localT);
+        ctx.strokeStyle = stroke;
+        ctx.beginPath();
+        ctx.moveTo(previous.x, previous.y);
+        ctx.lineTo(point.x, point.y);
+        ctx.stroke();
+      }
+      previous = point;
+    }
+
+    ctx.restore();
+
+    ctx.save();
+    ctx.globalAlpha = 0.65;
+    ctx.fillStyle = '#ffffff';
+    ctx.font = '600 14px "Inter", system-ui';
+    ctx.textAlign = 'right';
+    ctx.fillText(`ratio ${this.ratio}`, this.width - 24, this.height - 28);
+    ctx.restore();
+  }
+}
+
+const explain = `Lissajous figures use orthogonal sinusoidal motions x = A sin(a t + δ) and y = B sin(b t). Adding damped harmonograph terms creates the layered ribbons that slowly settle as e^{-λ t}. Integer frequency ratios a:b close the curve into delicate knots.`;
+
+export default {
+  id: 'lissajous',
+  name: 'Lissajous & Harmonograph',
+  explain,
+  create: (env, saved) => new LissajousHarmonograph(env, saved),
+};

--- a/js/demos/mod-mult-circle.js
+++ b/js/demos/mod-mult-circle.js
@@ -1,0 +1,167 @@
+// js/demos/mod-mult-circle.js
+// Modular multiplication circle revealing cardioid and epicycloid patterns.
+import {
+  TAU,
+  createSeededRng,
+  pickPalette,
+  getPaletteNames,
+  clamp,
+  lerp,
+  mapRange,
+  setCanvasBackground,
+  generateSeed,
+} from '../utils.js';
+
+class ModularMultiplicationCircle {
+  constructor(env, saved = {}) {
+    this.ctx = env.ctx;
+    this.width = env.width;
+    this.height = env.height;
+    this.calm = Boolean(env.calm);
+
+    this.seed = saved.seed ?? 314159;
+    this.pointCount = saved.points ?? (this.calm ? 160 : 260);
+    this.speed = saved.speed ?? (this.calm ? 0.15 : 0.35);
+    this.paletteName = saved.palette ?? 'aurora';
+
+    this.multiplier = saved.multiplier ?? 2.2;
+    this.scrollTarget = this.multiplier;
+
+    this.rng = createSeededRng(this.seed);
+    this.palette = pickPalette(this.paletteName);
+
+    this.points = [];
+    this.computePoints();
+  }
+
+  getSettings() {
+    return [
+      { id: 'seed', label: 'Seed', type: 'integer', min: 1, max: 999999, value: this.seed },
+      { id: 'points', label: 'Points on Circle', type: 'range', min: 60, max: 600, step: 10, value: this.pointCount },
+      { id: 'speed', label: 'Multiplier Speed', type: 'range', min: 0.02, max: 1, step: 0.01, value: this.speed },
+      {
+        id: 'palette',
+        label: 'Palette',
+        type: 'select',
+        options: getPaletteNames().map((name) => ({ value: name, label: name })),
+        value: this.paletteName,
+      },
+    ];
+  }
+
+  updateSetting(id, value) {
+    if (id === 'seed') {
+      this.seed = Math.max(1, Number(value));
+      this.rng = createSeededRng(this.seed);
+      this.computePoints();
+    } else if (id === 'points') {
+      this.pointCount = Math.round(value);
+      this.computePoints();
+    } else if (id === 'speed') {
+      this.speed = Number(value);
+    } else if (id === 'palette') {
+      this.paletteName = value;
+      this.palette = pickPalette(value);
+    }
+  }
+
+  reset() {
+    this.seed = generateSeed();
+    this.rng = createSeededRng(this.seed);
+    this.multiplier = 2;
+    this.scrollTarget = this.multiplier;
+    this.computePoints();
+  }
+
+  setCalmMode(enabled) {
+    this.calm = enabled;
+    this.pointCount = enabled ? Math.min(this.pointCount, 180) : Math.max(this.pointCount, 220);
+    this.speed = enabled ? Math.min(this.speed, 0.22) : Math.max(this.speed, 0.35);
+    this.computePoints();
+  }
+
+  resize({ width, height }) {
+    this.width = width;
+    this.height = height;
+    this.computePoints();
+  }
+
+  computePoints() {
+    const radius = Math.min(this.width, this.height) * 0.42;
+    this.points = new Array(this.pointCount).fill(0).map((_, i) => {
+      const angle = (i / this.pointCount) * TAU;
+      return {
+        x: this.width / 2 + radius * Math.cos(angle),
+        y: this.height / 2 + radius * Math.sin(angle),
+        angle,
+      };
+    });
+  }
+
+  handleScroll({ deltaY }) {
+    const direction = Math.sign(deltaY);
+    const next = clamp(this.scrollTarget + direction * -0.35, 0.2, 25);
+    this.scrollTarget = next;
+    return true;
+  }
+
+  update(dt) {
+    const drift = this.speed * (this.calm ? 0.6 : 1);
+    this.scrollTarget += dt * drift;
+    this.multiplier = lerp(this.multiplier, this.scrollTarget, clamp(0.5 * dt, 0, 1));
+  }
+
+  interpolatePoint(index) {
+    const points = this.points;
+    const count = points.length;
+    const base = Math.floor(index);
+    const frac = index - base;
+    const a = points[base % count];
+    const b = points[(base + 1) % count];
+    return {
+      x: lerp(a.x, b.x, frac),
+      y: lerp(a.y, b.y, frac),
+    };
+  }
+
+  render(ctx) {
+    setCanvasBackground(ctx, this.width, this.height, '#02030a');
+    ctx.save();
+    ctx.lineWidth = this.calm ? 0.6 : 0.9;
+    ctx.globalAlpha = this.calm ? 0.8 : 0.92;
+    const palette = this.palette;
+    const count = this.points.length;
+
+    for (let i = 0; i < count; i += 1) {
+      const start = this.points[i];
+      const mappedIndex = (i * this.multiplier) % count;
+      const end = this.interpolatePoint(mappedIndex);
+      const t = mapRange(i, 0, count - 1, 0, 1);
+      const color = palette[Math.floor(t * (palette.length - 1))];
+      ctx.beginPath();
+      ctx.strokeStyle = color;
+      ctx.moveTo(start.x, start.y);
+      ctx.lineTo(end.x, end.y);
+      ctx.stroke();
+    }
+
+    ctx.restore();
+
+    ctx.save();
+    ctx.globalAlpha = 0.35;
+    ctx.fillStyle = 'white';
+    ctx.font = '600 14px/1.2 "Inter", system-ui';
+    ctx.textAlign = 'center';
+    ctx.fillText(`multiplier m = ${this.multiplier.toFixed(2)}`, this.width / 2, this.height * 0.08);
+    ctx.restore();
+  }
+}
+
+const explain = `Multiplying each index i by m and mapping back into the circle modulo N traces chords whose envelope forms cardioids when m is close to N. Changing m animates families of epicycloids and lissajous-like tangles.`;
+
+export default {
+  id: 'mod-mult-circle',
+  name: 'Modular Multiplication Circle',
+  explain,
+  create: (env, saved) => new ModularMultiplicationCircle(env, saved),
+};

--- a/js/demos/moire.js
+++ b/js/demos/moire.js
@@ -1,0 +1,202 @@
+// js/demos/moire.js
+// Moiré interference patterns from layered grids.
+import {
+  setCanvasBackground,
+  getPaletteNames,
+  pickPalette,
+} from '../utils.js';
+
+class MoireDemo {
+  constructor(env, saved = {}) {
+    this.ctx = env.ctx;
+    this.width = env.width;
+    this.height = env.height;
+    this.calm = Boolean(env.calm);
+
+    this.mode = saved.mode ?? 'lines';
+    this.phase = saved.phase ?? 0;
+    this.frequency = saved.frequency ?? 14;
+    this.speed = saved.speed ?? (this.calm ? 0.08 : 0.18);
+    this.snap = saved.snap ?? false;
+    this.paletteName = saved.palette ?? 'twilight';
+
+    this.palette = pickPalette(this.paletteName);
+  }
+
+  getSettings() {
+    return [
+      {
+        id: 'mode',
+        label: 'Pattern',
+        type: 'select',
+        options: [
+          { value: 'lines', label: 'Linear grids' },
+          { value: 'circles', label: 'Circular ripples' },
+          { value: 'ellipses', label: 'Elliptical' },
+        ],
+        value: this.mode,
+      },
+      { id: 'frequency', label: 'Base Frequency', type: 'range', min: 4, max: 40, step: 1, value: this.frequency },
+      { id: 'speed', label: 'Drift speed', type: 'range', min: 0.02, max: 0.4, step: 0.01, value: this.speed },
+      { id: 'snap', label: 'Snap to simple ratios', type: 'checkbox', value: this.snap },
+      {
+        id: 'palette',
+        label: 'Palette',
+        type: 'select',
+        options: getPaletteNames().map((name) => ({ value: name, label: name })),
+        value: this.paletteName,
+      },
+    ];
+  }
+
+  updateSetting(id, value) {
+    if (id === 'mode') {
+      this.mode = value;
+    } else if (id === 'frequency') {
+      this.frequency = Number(value);
+    } else if (id === 'speed') {
+      this.speed = Number(value);
+    } else if (id === 'snap') {
+      this.snap = Boolean(value);
+    } else if (id === 'palette') {
+      this.paletteName = value;
+      this.palette = pickPalette(value);
+    }
+  }
+
+  reset() {
+    this.phase = 0;
+  }
+
+  setCalmMode(enabled) {
+    this.calm = enabled;
+    this.speed = enabled ? Math.min(this.speed, 0.1) : Math.max(this.speed, 0.18);
+  }
+
+  resize({ width, height }) {
+    this.width = width;
+    this.height = height;
+  }
+
+  handleScroll({ deltaY }) {
+    const direction = Math.sign(deltaY);
+    this.phase += direction * -0.2;
+    return true;
+  }
+
+  update(dt) {
+    this.phase += dt * this.speed;
+  }
+
+  render(ctx) {
+    setCanvasBackground(ctx, this.width, this.height, '#020206');
+    ctx.save();
+    ctx.globalAlpha = this.calm ? 0.85 : 1;
+
+    if (this.mode === 'lines') {
+      this.drawLineGrids(ctx);
+    } else if (this.mode === 'circles') {
+      this.drawCircleGrids(ctx);
+    } else {
+      this.drawEllipseGrids(ctx);
+    }
+
+    ctx.restore();
+  }
+
+  drawLineGrids(ctx) {
+    const spacing = Math.max(6, 180 / this.frequency);
+    const offset = (this.phase % 1) * spacing;
+    const palette = this.palette;
+
+    ctx.lineWidth = 1;
+    for (let i = -this.width; i < this.width * 2; i += spacing) {
+      const color = palette[Math.floor((i / spacing) % palette.length + palette.length) % palette.length];
+      ctx.strokeStyle = color;
+      ctx.beginPath();
+      ctx.moveTo(i + offset, 0);
+      ctx.lineTo(i + offset, this.height);
+      ctx.stroke();
+    }
+
+    const ratio = this.snap ? this.getSnapRatio() : 1.08;
+    const spacing2 = spacing * ratio;
+    const offset2 = ((this.phase * 1.6) % 1) * spacing2;
+    ctx.globalCompositeOperation = 'screen';
+    for (let i = -this.width; i < this.width * 2; i += spacing2) {
+      const color = palette[(Math.floor(i / spacing2) + 2) % palette.length];
+      ctx.strokeStyle = color;
+      ctx.beginPath();
+      ctx.moveTo(0, i + offset2);
+      ctx.lineTo(this.width, i + offset2);
+      ctx.stroke();
+    }
+  }
+
+  drawCircleGrids(ctx) {
+    const spacing = Math.max(12, 250 / this.frequency);
+    const ratio = this.snap ? this.getSnapRatio() : 1.04;
+    const maxRadius = Math.hypot(this.width, this.height);
+    const offset = (this.phase % 1) * spacing;
+    ctx.lineWidth = 0.8;
+    const palette = this.palette;
+
+    for (let r = offset; r < maxRadius; r += spacing) {
+      ctx.strokeStyle = palette[Math.floor(r / spacing) % palette.length];
+      ctx.beginPath();
+      ctx.arc(this.width / 2, this.height / 2, r, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+
+    ctx.globalCompositeOperation = 'screen';
+    const offset2 = ((this.phase * 1.3) % 1) * spacing * ratio;
+    for (let r = offset2; r < maxRadius; r += spacing * ratio) {
+      const color = palette[(Math.floor(r / (spacing * ratio)) + 2) % palette.length];
+      ctx.strokeStyle = color;
+      ctx.beginPath();
+      ctx.arc(this.width / 2 + spacing * 0.35, this.height / 2 + spacing * 0.1, r, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+
+  drawEllipseGrids(ctx) {
+    const spacing = Math.max(10, 220 / this.frequency);
+    const ratio = this.snap ? this.getSnapRatio() : 1.05;
+    const palette = this.palette;
+    const offset = (this.phase % 1) * spacing;
+    ctx.lineWidth = 1;
+
+    for (let r = offset; r < Math.max(this.width, this.height) * 1.2; r += spacing) {
+      const color = palette[Math.floor(r / spacing) % palette.length];
+      ctx.strokeStyle = color;
+      ctx.beginPath();
+      ctx.ellipse(this.width / 2, this.height / 2, r * 1.1, r * 0.6, 0, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+
+    ctx.globalCompositeOperation = 'screen';
+    const offset2 = ((this.phase * 1.5) % 1) * spacing * ratio;
+    for (let r = offset2; r < Math.max(this.width, this.height) * 1.2; r += spacing * ratio) {
+      const color = palette[(Math.floor(r / (spacing * ratio)) + 1) % palette.length];
+      ctx.strokeStyle = color;
+      ctx.beginPath();
+      ctx.ellipse(this.width / 2 + spacing * 0.4, this.height / 2, r * 0.7, r * 1.1, 0, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+
+  getSnapRatio() {
+    const ratios = [3 / 2, 5 / 4, 4 / 3, 8 / 5];
+    const index = Math.floor(Math.abs(this.phase * 3)) % ratios.length;
+    return ratios[index];
+  }
+}
+
+const explain = 'Moiré patterns emerge when regular grids interfere. Here two lattices with slightly different frequencies overlay to create sweeping beats. Snapping the frequency ratio to musical intervals like 3:2 or 5:4 generates stable lobes.';
+
+export default {
+  id: 'moire',
+  name: 'Moiré Interference',
+  explain,
+  create: (env, saved) => new MoireDemo(env, saved),
+};

--- a/js/demos/penrose.js
+++ b/js/demos/penrose.js
@@ -1,0 +1,162 @@
+// js/demos/penrose.js
+// Penrose tiling via triangle inflation executed in a worker.
+import {
+  setCanvasBackground,
+  pickPalette,
+  getPaletteNames,
+} from '../utils.js';
+
+const workerUrl = new URL('../../workers/penrose.js', import.meta.url);
+
+class PenroseDemo {
+  constructor(env, saved = {}) {
+    this.ctx = env.ctx;
+    this.width = env.width;
+    this.height = env.height;
+    this.calm = Boolean(env.calm);
+
+    this.iterations = saved.iterations ?? (this.calm ? 2 : 3);
+    this.paletteName = saved.palette ?? 'sunflower';
+    this.rotation = saved.rotation ?? 0;
+    this.autoRotate = saved.autoRotate ?? true;
+
+    this.palette = pickPalette(this.paletteName);
+    this.worker = new Worker(workerUrl, { type: 'module' });
+    this.worker.onmessage = (event) => {
+      const data = event.data;
+      if (data?.type === 'result') {
+        this.triangleBuffer = new Float32Array(data.triangles);
+        this.typeBuffer = new Uint8Array(data.kinds);
+        this.bounds = data.bounds;
+        this.pending = false;
+      }
+    };
+
+    this.compute();
+  }
+
+  getSettings() {
+    return [
+      { id: 'iterations', label: 'Inflation steps', type: 'range', min: 1, max: 5, step: 1, value: this.iterations },
+      { id: 'rotation', label: 'Manual rotation', type: 'range', min: -Math.PI, max: Math.PI, step: 0.01, value: this.rotation },
+      { id: 'autoRotate', label: 'Auto rotate', type: 'checkbox', value: this.autoRotate },
+      {
+        id: 'palette',
+        label: 'Palette',
+        type: 'select',
+        options: getPaletteNames().map((name) => ({ value: name, label: name })),
+        value: this.paletteName,
+      },
+    ];
+  }
+
+  updateSetting(id, value) {
+    if (id === 'iterations') {
+      this.iterations = Math.round(value);
+      this.compute();
+    } else if (id === 'rotation') {
+      this.rotation = Number(value);
+    } else if (id === 'autoRotate') {
+      this.autoRotate = Boolean(value);
+    } else if (id === 'palette') {
+      this.paletteName = value;
+      this.palette = pickPalette(value);
+    }
+  }
+
+  reset() {
+    this.rotation = 0;
+  }
+
+  setCalmMode(enabled) {
+    this.calm = enabled;
+    this.iterations = enabled ? Math.min(this.iterations, 2) : Math.max(this.iterations, 3);
+    this.compute();
+  }
+
+  resize({ width, height }) {
+    this.width = width;
+    this.height = height;
+  }
+
+  handleScroll({ deltaY }) {
+    this.rotation += Math.sign(deltaY) * 0.05;
+    return true;
+  }
+
+  compute() {
+    if (!this.worker) return;
+    this.pending = true;
+    this.worker.postMessage({ type: 'inflate', iterations: this.iterations });
+  }
+
+  update(dt) {
+    if (this.autoRotate) {
+      this.rotation += dt * 0.1;
+    }
+  }
+
+  render(ctx) {
+    setCanvasBackground(ctx, this.width, this.height, '#050407');
+    if (!this.triangleBuffer || !this.typeBuffer || !this.bounds) {
+      if (this.pending) {
+        ctx.save();
+        ctx.fillStyle = '#ffffffaa';
+        ctx.font = '600 14px "Inter", system-ui';
+        ctx.textAlign = 'center';
+        ctx.fillText('Inflating tiles…', this.width / 2, this.height / 2);
+        ctx.restore();
+      }
+      return;
+    }
+
+    const triangles = this.triangleBuffer;
+    const types = this.typeBuffer;
+    const palette = this.palette;
+    const rangeX = this.bounds.maxX - this.bounds.minX || 1;
+    const rangeY = this.bounds.maxY - this.bounds.minY || 1;
+    const scale = 0.9 * Math.min(this.width / rangeX, this.height / rangeY);
+    const offsetX = this.width / 2;
+    const offsetY = this.height / 2;
+
+    ctx.save();
+    ctx.translate(offsetX, offsetY);
+    ctx.rotate(this.rotation);
+    ctx.translate(-rangeX / 2 * scale, -rangeY / 2 * scale);
+
+    for (let i = 0; i < types.length; i += 1) {
+      const idx = i * 6;
+      const ax = (triangles[idx] - this.bounds.minX) * scale;
+      const ay = (triangles[idx + 1] - this.bounds.minY) * scale;
+      const bx = (triangles[idx + 2] - this.bounds.minX) * scale;
+      const by = (triangles[idx + 3] - this.bounds.minY) * scale;
+      const cx = (triangles[idx + 4] - this.bounds.minX) * scale;
+      const cy = (triangles[idx + 5] - this.bounds.minY) * scale;
+
+      ctx.beginPath();
+      ctx.moveTo(ax, ay);
+      ctx.lineTo(bx, by);
+      ctx.lineTo(cx, cy);
+      ctx.closePath();
+
+      const kind = types[i];
+      const fill = kind ? palette[0] : palette[2] || '#ffffff';
+      ctx.fillStyle = fill.replace('rgb', 'rgba').replace(')', kind ? ', 0.5)' : ', 0.35)');
+      ctx.strokeStyle = kind ? palette[palette.length - 1] : palette[1] || '#ffffff';
+      ctx.lineWidth = this.calm ? 0.5 : 0.8;
+      ctx.fill();
+      ctx.stroke();
+    }
+
+    ctx.restore();
+  }
+}
+
+const explain = 'Penrose tilings force aperiodic order through matching rules on kite and dart shapes. Inflation replaces each tile with a scaled arrangement of kites/darts, converging to a non-repeating quasiperiodic pattern related to the golden ratio.';
+
+export default {
+  id: 'penrose',
+  name: 'Penrose Kites & Darts',
+  explain,
+  create: (env, saved) => new PenroseDemo(env, saved),
+};

--- a/js/demos/phyllotaxis.js
+++ b/js/demos/phyllotaxis.js
@@ -1,0 +1,179 @@
+// js/demos/phyllotaxis.js
+// Phyllotaxis sunflower visualization based on the golden angle arrangement.
+import {
+  GOLDEN_ANGLE_RAD,
+  GOLDEN_ANGLE_DEG,
+  createSeededRng,
+  pickPalette,
+  getPaletteNames,
+  clamp,
+  lerp,
+  setCanvasBackground,
+  generateSeed,
+} from '../utils.js';
+
+class PhyllotaxisSunflower {
+  constructor(env, saved = {}) {
+    this.ctx = env.ctx;
+    this.canvas = env.canvas;
+    this.width = env.width;
+    this.height = env.height;
+    this.calm = Boolean(env.calm);
+
+    this.seed = saved.seed ?? 20240517;
+    this.pointCount = saved.density ?? (this.calm ? 800 : 1600);
+    this.bandModulo = saved.bandModulo ?? 12;
+    this.speed = saved.speed ?? (this.calm ? 0.35 : 0.65);
+    this.paletteName = saved.palette ?? 'sunflower';
+
+    this.rng = createSeededRng(this.seed);
+    this.palette = pickPalette(this.paletteName);
+
+    this.points = [];
+    this.visibleCount = 0;
+    this.targetCount = this.pointCount;
+    this.rotation = 0;
+
+    this.computePoints();
+  }
+
+  getSettings() {
+    return [
+      { id: 'seed', label: 'Seed', type: 'integer', min: 1, max: 999999999, value: this.seed, step: 1 },
+      { id: 'density', label: 'Points', type: 'range', min: 200, max: 5000, step: 20, value: this.pointCount },
+      { id: 'bandModulo', label: 'Color Bands', type: 'range', min: 2, max: 36, step: 1, value: this.bandModulo },
+      { id: 'speed', label: 'Growth Speed', type: 'range', min: 0.1, max: 1.5, step: 0.05, value: this.speed },
+      {
+        id: 'palette',
+        label: 'Palette',
+        type: 'select',
+        options: getPaletteNames().map((name) => ({ value: name, label: name })),
+        value: this.paletteName,
+      },
+    ];
+  }
+
+  updateSetting(id, value) {
+    if (id === 'seed') {
+      this.seed = Math.max(1, Number(value));
+      this.rng = createSeededRng(this.seed);
+      this.computePoints();
+    } else if (id === 'density') {
+      this.pointCount = Math.round(value);
+      this.targetCount = this.pointCount;
+      this.computePoints();
+    } else if (id === 'bandModulo') {
+      this.bandModulo = Math.max(2, Math.round(value));
+    } else if (id === 'speed') {
+      this.speed = Number(value);
+    } else if (id === 'palette') {
+      this.paletteName = value;
+      this.palette = pickPalette(value);
+    }
+  }
+
+  reset() {
+    this.seed = generateSeed();
+    this.rng = createSeededRng(this.seed);
+    this.computePoints();
+  }
+
+  setCalmMode(enabled) {
+    this.calm = enabled;
+    const nextDensity = enabled ? Math.min(this.pointCount, 900) : Math.max(this.pointCount, 1600);
+    this.pointCount = nextDensity;
+    this.targetCount = this.pointCount;
+    this.speed = enabled ? Math.min(this.speed, 0.45) : Math.max(this.speed, 0.6);
+    this.computePoints();
+  }
+
+  resize({ width, height }) {
+    this.width = width;
+    this.height = height;
+    this.computePoints();
+  }
+
+  computePoints() {
+    // Phyllotaxis uses r = c * sqrt(k) and theta = k * golden angle.
+    // The scale constant c determines the spacing between seeds.
+    const maxDimension = Math.min(this.width, this.height);
+    const scale = (maxDimension * 0.5) / Math.sqrt(this.pointCount + 1);
+    this.points = new Array(this.pointCount).fill(0).map((_, k) => {
+      const radius = scale * Math.sqrt(k);
+      const angle = k * GOLDEN_ANGLE_RAD;
+      const x = radius * Math.cos(angle);
+      const y = radius * Math.sin(angle);
+      return { x, y, k, radius };
+    });
+    this.visibleCount = Math.min(this.visibleCount, this.points.length);
+  }
+
+  handleScroll({ deltaY }) {
+    const direction = Math.sign(deltaY);
+    const next = clamp(this.pointCount + direction * -80, 200, 6000);
+    if (next !== this.pointCount) {
+      this.pointCount = next;
+      this.targetCount = next;
+      this.computePoints();
+    }
+    return true;
+  }
+
+  update(dt) {
+    const growthRate = this.speed * (this.calm ? 0.6 : 1);
+    const target = Math.min(this.pointCount, this.points.length);
+    this.visibleCount = lerp(this.visibleCount, target, clamp(growthRate * dt, 0, 1));
+    this.rotation += dt * 0.05 * (this.calm ? 0.3 : 1);
+  }
+
+  render(ctx) {
+    setCanvasBackground(ctx, this.width, this.height, '#05060a');
+    ctx.save();
+    ctx.translate(this.width / 2, this.height / 2);
+    ctx.rotate(this.rotation);
+    const drawCount = Math.floor(this.visibleCount);
+    const palette = this.palette;
+    const modulo = Math.max(1, this.bandModulo);
+
+    for (let i = 0; i < drawCount; i += 1) {
+      const point = this.points[i];
+      const colorIndex = point.k % modulo;
+      const color = palette[colorIndex % palette.length];
+      const size = Math.max(2.2 - point.radius / (this.width * 0.6), 0.6);
+      ctx.fillStyle = color;
+      ctx.beginPath();
+      ctx.arc(point.x, point.y, size, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.restore();
+
+    // Overlay subtle radial gradient to suggest sunflower structure.
+    ctx.save();
+    ctx.globalCompositeOperation = 'lighter';
+    const gradient = ctx.createRadialGradient(
+      this.width / 2,
+      this.height / 2,
+      0,
+      this.width / 2,
+      this.height / 2,
+      Math.min(this.width, this.height) * 0.6
+    );
+    gradient.addColorStop(0, 'rgba(255, 255, 255, 0.05)');
+    gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, this.width, this.height);
+    ctx.restore();
+  }
+}
+
+const explain = `Phyllotaxis arranges seeds by incrementing angle by the golden angle (${GOLDEN_ANGLE_DEG.toFixed(
+  3
+)}°).
+This irrational increment minimizes overlap so the spirals balance between clockwise and counterclockwise arms.`;
+
+export default {
+  id: 'phyllotaxis',
+  name: 'Phyllotaxis Sunflower',
+  explain,
+  create: (env, saved) => new PhyllotaxisSunflower(env, saved),
+};

--- a/js/demos/ulam.js
+++ b/js/demos/ulam.js
@@ -1,0 +1,229 @@
+// js/demos/ulam.js
+// Ulam spiral with primes computed in a Web Worker.
+import {
+  clamp,
+  pickPalette,
+  getPaletteNames,
+  setCanvasBackground,
+  lerp,
+  createSeededRng,
+  generateSeed,
+} from '../utils.js';
+
+const sieveWorkerUrl = new URL('../../workers/sieve.js', import.meta.url);
+
+function spiralCoordinate(n) {
+  if (n === 1) return { x: 0, y: 0 };
+  const k = Math.ceil((Math.sqrt(n) - 1) / 2);
+  const t = 2 * k + 1;
+  let m = t * t;
+  const tMinus = t - 1;
+  if (n >= m - tMinus) {
+    return { x: k - (m - n), y: -k };
+  }
+  m -= tMinus;
+  if (n >= m - tMinus) {
+    return { x: -k, y: -k + (m - n) };
+  }
+  m -= tMinus;
+  if (n >= m - tMinus) {
+    return { x: -k + (m - n), y: k };
+  }
+  return { x: k, y: k - (m - n - tMinus) };
+}
+
+class UlamSpiral {
+  constructor(env, saved = {}) {
+    this.ctx = env.ctx;
+    this.width = env.width;
+    this.height = env.height;
+    this.calm = Boolean(env.calm);
+
+    this.seed = saved.seed ?? 123456;
+    this.maxNumber = saved.max ?? (this.calm ? 16000 : 36000);
+    this.scale = saved.scale ?? 12;
+    this.paletteName = saved.palette ?? 'meadow';
+    this.showDiagonals = saved.diagonals ?? true;
+
+    this.palette = pickPalette(this.paletteName);
+    this.rng = createSeededRng(this.seed);
+
+    this.pan = { x: 0, y: 0 };
+    this.targetScale = this.scale;
+    this.positions = [];
+    this.trace = [];
+    this.primes = null;
+    this.isLoading = false;
+
+    this.worker = new Worker(sieveWorkerUrl, { type: 'module' });
+    this.worker.onmessage = (event) => {
+      if (event.data?.type === 'sieve-result') {
+        this.primes = new Uint8Array(event.data.buffer);
+        this.isLoading = false;
+      }
+    };
+
+    this.computePositions();
+    this.requestPrimes();
+  }
+
+  getSettings() {
+    return [
+      { id: 'seed', label: 'Seed', type: 'integer', min: 1, max: 999999, value: this.seed },
+      { id: 'max', label: 'Max Number', type: 'range', min: 1000, max: 90000, step: 1000, value: this.maxNumber },
+      { id: 'scale', label: 'Cell Size', type: 'range', min: 6, max: 32, step: 1, value: this.scale },
+      {
+        id: 'palette',
+        label: 'Palette',
+        type: 'select',
+        options: getPaletteNames().map((name) => ({ value: name, label: name })),
+        value: this.paletteName,
+      },
+      { id: 'diagonals', label: 'Highlight diagonals', type: 'checkbox', value: this.showDiagonals },
+    ];
+  }
+
+  updateSetting(id, value) {
+    if (id === 'seed') {
+      this.seed = Math.max(1, Number(value));
+      this.rng = createSeededRng(this.seed);
+    } else if (id === 'max') {
+      this.maxNumber = Math.round(value);
+      this.computePositions();
+      this.requestPrimes();
+    } else if (id === 'scale') {
+      this.scale = Number(value);
+      this.targetScale = this.scale;
+    } else if (id === 'palette') {
+      this.paletteName = value;
+      this.palette = pickPalette(value);
+    } else if (id === 'diagonals') {
+      this.showDiagonals = Boolean(value);
+    }
+  }
+
+  reset() {
+    this.seed = generateSeed();
+    this.rng = createSeededRng(this.seed);
+    this.pan = { x: 0, y: 0 };
+  }
+
+  setCalmMode(enabled) {
+    this.calm = enabled;
+    this.maxNumber = enabled ? Math.min(this.maxNumber, 20000) : Math.max(this.maxNumber, 32000);
+    this.scale = enabled ? Math.max(8, this.scale * 0.85) : Math.min(16, this.scale * 1.1);
+    this.targetScale = this.scale;
+    this.computePositions();
+    this.requestPrimes();
+  }
+
+  resize({ width, height }) {
+    this.width = width;
+    this.height = height;
+  }
+
+  dispose() {
+    this.worker?.terminate();
+  }
+
+  computePositions() {
+    this.positions = new Array(this.maxNumber + 1);
+    for (let n = 1; n <= this.maxNumber; n += 1) {
+      this.positions[n] = spiralCoordinate(n);
+    }
+  }
+
+  requestPrimes() {
+    this.isLoading = true;
+    this.worker.postMessage({ type: 'sieve', max: this.maxNumber });
+  }
+
+  handleScroll({ deltaY, ctrlKey }) {
+    if (ctrlKey) {
+      const factor = Math.exp(-deltaY * 0.0025);
+      this.targetScale = clamp(this.targetScale * factor, 4, 48);
+    } else {
+      const direction = Math.sign(deltaY);
+      this.maxNumber = clamp(this.maxNumber + direction * -2000, 2000, 120000);
+      this.computePositions();
+      this.requestPrimes();
+    }
+    return true;
+  }
+
+  pointerDown(event) {
+    this.dragStart = { x: event.clientX, y: event.clientY };
+    this.panStart = { ...this.pan };
+  }
+
+  pointerDrag(event) {
+    if (!this.dragStart) return;
+    const dx = event.clientX - this.dragStart.x;
+    const dy = event.clientY - this.dragStart.y;
+    const cell = this.scale;
+    this.pan.x = this.panStart.x + dx / cell;
+    this.pan.y = this.panStart.y + dy / cell;
+  }
+
+  pointerUp() {
+    this.dragStart = null;
+  }
+
+  update(dt) {
+    this.scale = lerp(this.scale, this.targetScale, clamp(dt * 6, 0, 1));
+  }
+
+  render(ctx) {
+    setCanvasBackground(ctx, this.width, this.height, '#03040f');
+    if (!this.positions.length) return;
+
+    ctx.save();
+    ctx.translate(this.width / 2 + this.pan.x * this.scale, this.height / 2 + this.pan.y * this.scale);
+
+    const halfWidth = this.width / (2 * this.scale) + 2;
+    const halfHeight = this.height / (2 * this.scale) + 2;
+    const palette = this.palette;
+    const cell = this.scale;
+    const primeData = this.primes;
+
+    for (let n = 1; n <= this.maxNumber; n += 1) {
+      const point = this.positions[n];
+      if (!point) continue;
+      if (Math.abs(point.x + this.pan.x) > halfWidth || Math.abs(point.y + this.pan.y) > halfHeight) {
+        continue;
+      }
+
+      const screenX = point.x * cell;
+      const screenY = point.y * cell;
+      const isPrime = primeData ? primeData[n] === 1 : false;
+      const isDiagonal = this.showDiagonals && (point.x === point.y || point.x === -point.y || point.x === 0 || point.y === 0);
+
+      if (!isPrime && !isDiagonal) continue;
+
+      const size = Math.max(1, cell * (isPrime ? 0.82 : 0.5));
+      const color = isPrime ? palette[n % palette.length] : 'rgba(255,255,255,0.08)';
+      ctx.fillStyle = color;
+      ctx.fillRect(screenX - size / 2, screenY - size / 2, size, size);
+    }
+
+    ctx.restore();
+
+    if (this.isLoading) {
+      ctx.save();
+      ctx.fillStyle = '#ffffffaa';
+      ctx.font = '600 14px "Inter", system-ui';
+      ctx.textAlign = 'right';
+      ctx.fillText('Computing primes…', this.width - 24, this.height - 24);
+      ctx.restore();
+    }
+  }
+}
+
+const explain = 'The Ulam spiral enumerates integers along a square spiral. Primes cluster along quadratic polynomials, producing diagonal streaks. We use a Web Worker to run the Sieve of Eratosthenes and highlight primes without blocking rendering.';
+
+export default {
+  id: 'ulam',
+  name: 'Ulam Prime Spiral',
+  explain,
+  create: (env, saved) => new UlamSpiral(env, saved),
+};

--- a/js/demos/voronoi.js
+++ b/js/demos/voronoi.js
@@ -1,0 +1,214 @@
+// js/demos/voronoi.js
+// Voronoi diagram with Lloyd relaxation performed in a worker.
+import {
+  pickPalette,
+  getPaletteNames,
+  setCanvasBackground,
+  createSeededRng,
+  clamp,
+  generateSeed,
+} from '../utils.js';
+
+const workerUrl = new URL('../../workers/voronoi.js', import.meta.url);
+
+class VoronoiDemo {
+  constructor(env, saved = {}) {
+    this.ctx = env.ctx;
+    this.width = env.width;
+    this.height = env.height;
+    this.calm = Boolean(env.calm);
+
+    this.seed = saved.seed ?? 424242;
+    this.siteCount = saved.count ?? (this.calm ? 40 : 70);
+    this.iterations = saved.iterations ?? (this.calm ? 1 : 2);
+    this.paletteName = saved.palette ?? 'meadow';
+    this.showEdges = saved.showEdges ?? true;
+
+    this.palette = pickPalette(this.paletteName);
+    this.rng = createSeededRng(this.seed);
+
+    this.worker = new Worker(workerUrl, { type: 'module' });
+    this.worker.onmessage = (event) => {
+      const data = event.data;
+      if (data?.type === 'result') {
+        this.sites = new Float32Array(data.sites);
+        this.polygons = new Float32Array(data.polygons);
+        this.offsets = new Uint32Array(data.offsets);
+        this.counts = new Uint16Array(data.counts);
+        this.edges = new Float32Array(data.edges);
+        this.pending = false;
+      }
+    };
+
+    this.sites = new Float32Array();
+    this.polygons = new Float32Array();
+    this.offsets = new Uint32Array();
+    this.counts = new Uint16Array();
+    this.edges = new Float32Array();
+    this.pending = false;
+
+    this.generateSites();
+    this.computeDiagram();
+  }
+
+  getSettings() {
+    return [
+      { id: 'seed', label: 'Seed', type: 'integer', min: 1, max: 999999, value: this.seed },
+      { id: 'count', label: 'Sites', type: 'range', min: 10, max: 120, step: 5, value: this.siteCount },
+      { id: 'iterations', label: 'Lloyd Iterations', type: 'range', min: 0, max: 3, step: 1, value: this.iterations },
+      { id: 'showEdges', label: 'Show Delaunay edges', type: 'checkbox', value: this.showEdges },
+      {
+        id: 'palette',
+        label: 'Palette',
+        type: 'select',
+        options: getPaletteNames().map((name) => ({ value: name, label: name })),
+        value: this.paletteName,
+      },
+    ];
+  }
+
+  updateSetting(id, value) {
+    if (id === 'seed') {
+      this.seed = Math.max(1, Number(value));
+      this.rng = createSeededRng(this.seed);
+      this.generateSites();
+      this.computeDiagram();
+    } else if (id === 'count') {
+      this.siteCount = Math.round(value);
+      this.generateSites();
+      this.computeDiagram();
+    } else if (id === 'iterations') {
+      this.iterations = Math.round(value);
+      this.computeDiagram();
+    } else if (id === 'palette') {
+      this.paletteName = value;
+      this.palette = pickPalette(value);
+    } else if (id === 'showEdges') {
+      this.showEdges = Boolean(value);
+    }
+  }
+
+  reset() {
+    this.seed = generateSeed();
+    this.rng = createSeededRng(this.seed);
+    this.generateSites();
+    this.computeDiagram();
+  }
+
+  setCalmMode(enabled) {
+    this.calm = enabled;
+    this.siteCount = enabled ? Math.min(this.siteCount, 45) : Math.max(this.siteCount, 65);
+    this.iterations = enabled ? Math.min(this.iterations, 1) : Math.max(this.iterations, 2);
+    this.generateSites();
+    this.computeDiagram();
+  }
+
+  resize({ width, height }) {
+    this.width = width;
+    this.height = height;
+    this.computeDiagram();
+  }
+
+  dispose() {
+    this.worker?.terminate();
+  }
+
+  generateSites() {
+    const sites = new Float32Array(this.siteCount * 2);
+    for (let i = 0; i < this.siteCount; i += 1) {
+      sites[i * 2] = this.rng();
+      sites[i * 2 + 1] = this.rng();
+    }
+    this.baseSites = sites;
+  }
+
+  computeDiagram() {
+    if (!this.worker) return;
+    this.pending = true;
+    const points = this.baseSites.slice();
+    this.worker.postMessage(
+      {
+        type: 'compute',
+        points,
+        iterations: this.iterations,
+      },
+      [points.buffer]
+    );
+  }
+
+  handleScroll({ deltaY }) {
+    const direction = Math.sign(deltaY);
+    this.iterations = clamp(this.iterations + direction * -1, 0, 3);
+    this.computeDiagram();
+    return true;
+  }
+
+  update(dt) {
+    this.time = (this.time || 0) + dt;
+  }
+
+  render(ctx) {
+    setCanvasBackground(ctx, this.width, this.height, '#04060f');
+    if (!this.counts.length) {
+      if (this.pending) {
+        ctx.save();
+        ctx.fillStyle = '#ffffffaa';
+        ctx.font = '600 14px "Inter", system-ui';
+        ctx.textAlign = 'center';
+        ctx.fillText('Computing Voronoi…', this.width / 2, this.height / 2);
+        ctx.restore();
+      }
+      return;
+    }
+
+    const palette = this.palette;
+    ctx.save();
+    ctx.lineJoin = 'round';
+
+    for (let i = 0; i < this.counts.length; i += 1) {
+      const count = this.counts[i];
+      const offset = this.offsets[i];
+      ctx.beginPath();
+      for (let j = 0; j < count; j += 1) {
+        const x = this.polygons[(offset + j) * 2] * this.width;
+        const y = this.polygons[(offset + j) * 2 + 1] * this.height;
+        if (j === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.closePath();
+      const color = palette[i % palette.length];
+      const pulse = 0.08 * Math.sin(this.time * 0.5 + i * 0.3);
+      ctx.fillStyle = color.replace('rgb', 'rgba').replace(')', `, ${0.28 + pulse})`);
+      ctx.fill();
+      ctx.strokeStyle = color.replace('rgb', 'rgba').replace(')', ', 0.5)');
+      ctx.lineWidth = this.calm ? 0.7 : 1;
+      ctx.stroke();
+    }
+
+    if (this.showEdges && this.edges.length) {
+      ctx.lineWidth = this.calm ? 0.6 : 1;
+      ctx.strokeStyle = 'rgba(255,255,255,0.15)';
+      ctx.beginPath();
+      for (let i = 0; i < this.edges.length; i += 4) {
+        const x1 = this.edges[i] * this.width;
+        const y1 = this.edges[i + 1] * this.height;
+        const x2 = this.edges[i + 2] * this.width;
+        const y2 = this.edges[i + 3] * this.height;
+        ctx.moveTo(x1, y1);
+        ctx.lineTo(x2, y2);
+      }
+      ctx.stroke();
+    }
+
+    ctx.restore();
+  }
+}
+
+const explain = 'Voronoi regions contain points closer to their generator than any other. Lloyd relaxation repeatedly replaces each site with the centroid of its cell, converging to centroidal Voronoi tessellations used in blue-noise sampling and mesh generation.';
+
+export default {
+  id: 'voronoi',
+  name: 'Voronoi + Delaunay',
+  explain,
+  create: (env, saved) => new VoronoiDemo(env, saved),
+};

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,415 @@
+import {
+  TAU,
+  setCanvasSize,
+  createSeededRng,
+  createFPSCounter,
+  formatFPS,
+  throttle,
+  downloadCanvasPNG,
+  prefersReducedMotion,
+  listenPrefersReducedMotion,
+  storeState,
+  loadState,
+  detectMobile,
+  autoDropCalmMode,
+} from './utils.js';
+
+import phyllotaxisDemo from './demos/phyllotaxis.js';
+import modularCircleDemo from './demos/mod-mult-circle.js';
+import lissajousDemo from './demos/lissajous.js';
+import epicycleDemo from './demos/epicycles.js';
+import ulamDemo from './demos/ulam.js';
+import hilbertDemo from './demos/hilbert.js';
+import kochDemo from './demos/koch.js';
+import voronoiDemo from './demos/voronoi.js';
+import penroseDemo from './demos/penrose.js';
+import moireDemo from './demos/moire.js';
+import flowFieldDemo from './demos/flowfield.js';
+import goldenGridDemo from './demos/golden-grid.js';
+
+const demos = [
+  phyllotaxisDemo,
+  modularCircleDemo,
+  lissajousDemo,
+  epicycleDemo,
+  ulamDemo,
+  hilbertDemo,
+  kochDemo,
+  voronoiDemo,
+  penroseDemo,
+  moireDemo,
+  flowFieldDemo,
+  goldenGridDemo,
+];
+
+const canvas = document.getElementById('demo-canvas');
+const ctx = canvas.getContext('2d', { alpha: false, desynchronized: true });
+
+const demoSelect = document.getElementById('demo-select');
+const playPauseBtn = document.getElementById('play-pause');
+const calmToggle = document.getElementById('calm-toggle');
+const fpsMeter = document.getElementById('fps-meter');
+const downloadBtn = document.getElementById('download-btn');
+const resetBtn = document.getElementById('reset-demo');
+const settingsForm = document.getElementById('settings-form');
+const settingsTitle = document.getElementById('settings-title');
+const explainCheckbox = document.getElementById('explain-checkbox');
+const explainPanel = document.getElementById('explain-panel');
+const explainTitle = document.getElementById('explain-title');
+const explainContent = document.getElementById('explain-content');
+
+const storageKeys = {
+  demo: 'math-gallery:demo',
+  calm: 'math-gallery:calm-mode',
+  settings: 'math-gallery:settings',
+  explain: 'math-gallery:explain',
+};
+
+const state = {
+  current: null,
+  demoIndex: 0,
+  isPlaying: true,
+  calmMode: false,
+  shouldExplain: false,
+  fpsCounter: createFPSCounter(),
+  lastFrame: performance.now(),
+  autoDrop: null,
+  mobile: detectMobile(),
+  size: { width: window.innerWidth, height: window.innerHeight, dpr: 1 },
+  storedSettings: loadState(storageKeys.settings, {}),
+  autoPaused: false,
+  fpsTimer: 0,
+};
+
+let pointerDown = false;
+let pointerId = null;
+let rafHandle = null;
+
+function init() {
+  demos.forEach((demo, index) => {
+    const option = document.createElement('option');
+    option.value = demo.id;
+    option.textContent = demo.name;
+    option.dataset.index = index;
+    demoSelect.append(option);
+  });
+
+  const storedDemo = loadState(storageKeys.demo, demos[0].id);
+  const storedCalm = loadState(storageKeys.calm, null);
+  const storedExplain = loadState(storageKeys.explain, false);
+  state.calmMode = storedCalm !== null ? storedCalm : prefersReducedMotion() || state.mobile;
+  calmToggle.checked = state.calmMode;
+  state.shouldExplain = storedExplain;
+  explainCheckbox.checked = state.shouldExplain;
+
+  const defaultIndex = Math.max(0, demos.findIndex((demo) => demo.id === storedDemo));
+  state.demoIndex = defaultIndex === -1 ? 0 : defaultIndex;
+  demoSelect.value = demos[state.demoIndex].id;
+
+  handleResize();
+  swapDemo(state.demoIndex);
+
+  playPauseBtn.addEventListener('click', togglePlay);
+  calmToggle.addEventListener('change', (event) => {
+    setCalmMode(event.target.checked, { userInitiated: true });
+  });
+  downloadBtn.addEventListener('click', () => {
+    const descriptor = state.current?.descriptor;
+    const name = descriptor ? `${descriptor.id}.png` : 'math-demo.png';
+    downloadCanvasPNG(canvas, name);
+  });
+  resetBtn.addEventListener('click', () => {
+    state.current?.instance?.reset?.();
+    rebuildSettings();
+  });
+  explainCheckbox.addEventListener('change', (event) => {
+    state.shouldExplain = event.target.checked;
+    storeState(storageKeys.explain, state.shouldExplain);
+    updateExplainPanel();
+  });
+  demoSelect.addEventListener('change', (event) => {
+    const index = demos.findIndex((demo) => demo.id === event.target.value);
+    if (index !== -1) {
+      swapDemo(index);
+    }
+  });
+
+  window.addEventListener('resize', throttle(handleResize, 150));
+
+  canvas.addEventListener('wheel', (event) => {
+    if (state.current?.instance?.handleScroll) {
+      event.preventDefault();
+      const handled = state.current.instance.handleScroll({
+        deltaY: event.deltaY,
+        deltaX: event.deltaX,
+        ctrlKey: event.ctrlKey || event.metaKey,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+        originalEvent: event,
+      });
+      if (handled) return;
+    }
+    event.preventDefault();
+  }, { passive: false });
+
+  canvas.addEventListener('pointerdown', (event) => {
+    pointerDown = true;
+    pointerId = event.pointerId;
+    canvas.setPointerCapture(pointerId);
+    state.current?.instance?.pointerDown?.(event);
+  });
+
+  canvas.addEventListener('pointermove', (event) => {
+    if (!pointerDown || pointerId !== event.pointerId) {
+      state.current?.instance?.pointerMove?.(event);
+      return;
+    }
+    state.current?.instance?.pointerDrag?.(event);
+  });
+
+  const endPointer = (event) => {
+    if (pointerId !== event.pointerId) return;
+    pointerDown = false;
+    state.current?.instance?.pointerUp?.(event);
+    try {
+      canvas.releasePointerCapture(pointerId);
+    } catch (error) {
+      // ignore
+    }
+  };
+
+  canvas.addEventListener('pointerup', endPointer);
+  canvas.addEventListener('pointercancel', endPointer);
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      if (state.isPlaying) {
+        state.autoPaused = true;
+        togglePlay(false);
+      }
+    } else if (state.autoPaused) {
+      state.autoPaused = false;
+      togglePlay(true);
+    }
+  });
+
+  window.addEventListener('keydown', (event) => {
+    if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+      return;
+    }
+    if (event.code === 'Space') {
+      event.preventDefault();
+      togglePlay(!state.isPlaying);
+    } else if (event.code === 'ArrowRight') {
+      const next = (state.demoIndex + 1) % demos.length;
+      swapDemo(next);
+    } else if (event.code === 'ArrowLeft') {
+      const next = (state.demoIndex - 1 + demos.length) % demos.length;
+      swapDemo(next);
+    } else if (event.code === 'KeyS') {
+      event.preventDefault();
+      downloadBtn.click();
+    }
+  });
+
+  listenPrefersReducedMotion((matches) => {
+    if (matches && !state.calmMode) {
+      setCalmMode(true, { system: true });
+    }
+  });
+
+  setupAutoCalmWatcher();
+  requestAnimationFrame(loop);
+}
+
+function setupAutoCalmWatcher() {
+  state.autoDrop = autoDropCalmMode({
+    fps: () => state.fpsCounter,
+    calmMode: () => state.calmMode,
+    onDrop: () => setCalmMode(true, { auto: true }),
+  });
+}
+
+function handleResize() {
+  state.size = setCanvasSize(canvas, window.innerWidth, window.innerHeight, { maxDpr: 2 });
+  state.current?.instance?.resize?.({ ...state.size });
+}
+
+function swapDemo(index) {
+  const descriptor = demos[index];
+  if (!descriptor) return;
+  state.current?.instance?.dispose?.();
+  state.demoIndex = index;
+  state.current = {
+    descriptor,
+    instance: null,
+  };
+  settingsTitle.textContent = descriptor.name;
+  demoSelect.value = descriptor.id;
+  storeState(storageKeys.demo, descriptor.id);
+
+  const context = {
+    canvas,
+    ctx,
+    width: state.size.width,
+    height: state.size.height,
+    dpr: state.size.dpr,
+    calm: state.calmMode,
+    createSeededRng,
+    utils: {
+      TAU,
+      setCanvasSize,
+    },
+    mobile: state.mobile,
+  };
+
+  const saved = state.storedSettings[descriptor.id] || {};
+  const instance = descriptor.create(context, saved);
+  state.current.instance = instance;
+  state.current.descriptor = descriptor;
+  instance?.resize?.({ ...state.size });
+  instance?.setCalmMode?.(state.calmMode);
+  rebuildSettings();
+  updateExplainPanel();
+}
+
+function rebuildSettings() {
+  const descriptor = state.current?.descriptor;
+  const instance = state.current?.instance;
+  settingsForm.innerHTML = '';
+  if (!descriptor || !instance) return;
+  const settings = instance.getSettings?.() || [];
+  const stored = state.storedSettings[descriptor.id] || {};
+  const convertValue = (setting, input) => {
+    if (setting.type === 'checkbox') return Boolean(input);
+    if (setting.type === 'select') return input;
+    if (setting.type === 'range' || setting.type === 'number') return Number(input);
+    if (setting.type === 'integer') return Math.round(Number(input));
+    return input;
+  };
+
+  settings.forEach((setting) => {
+    const value = stored[setting.id] ?? setting.value;
+    const field = document.createElement('div');
+    field.className = 'field';
+    const label = document.createElement('label');
+    label.textContent = setting.label;
+    label.htmlFor = `setting-${setting.id}`;
+    field.append(label);
+
+    let input;
+    if (setting.type === 'select') {
+      input = document.createElement('select');
+      setting.options.forEach((option) => {
+        const opt = document.createElement('option');
+        opt.value = option.value;
+        opt.textContent = option.label;
+        input.append(opt);
+      });
+      input.value = value;
+    } else if (setting.type === 'checkbox') {
+      input = document.createElement('input');
+      input.type = 'checkbox';
+      input.checked = Boolean(value);
+    } else {
+      input = document.createElement('input');
+      if (setting.type === 'range') {
+        input.type = 'range';
+      } else if (setting.type === 'integer') {
+        input.type = 'number';
+        input.step = '1';
+      } else {
+        input.type = setting.inputType || setting.type || 'number';
+      }
+      if (setting.min !== undefined) input.min = setting.min;
+      if (setting.max !== undefined) input.max = setting.max;
+      if (setting.step !== undefined) input.step = setting.step;
+      input.value = value;
+    }
+
+    input.id = `setting-${setting.id}`;
+    input.addEventListener('change', (event) => {
+      const raw = setting.type === 'checkbox' ? event.target.checked : event.target.value;
+      const newValue = convertValue(setting, raw);
+      instance.updateSetting?.(setting.id, newValue);
+      const storedSettings = state.storedSettings[descriptor.id] || {};
+      storedSettings[setting.id] = newValue;
+      state.storedSettings[descriptor.id] = storedSettings;
+      storeState(storageKeys.settings, state.storedSettings);
+    });
+
+    if (setting.hint) {
+      const hint = document.createElement('small');
+      hint.textContent = setting.hint;
+      field.append(hint);
+    }
+
+    field.append(input);
+    settingsForm.append(field);
+
+    const applied = convertValue(setting, setting.type === 'checkbox' ? input.checked : input.value);
+    instance.updateSetting?.(setting.id, applied, { initial: true });
+  });
+}
+
+function togglePlay(next = !state.isPlaying) {
+  state.isPlaying = next;
+  playPauseBtn.textContent = state.isPlaying ? 'Pause' : 'Play';
+  playPauseBtn.setAttribute('aria-pressed', String(!state.isPlaying));
+  if (state.isPlaying) {
+    state.lastFrame = performance.now();
+    state.fpsCounter.reset();
+    requestAnimationFrame(loop);
+  }
+}
+
+function setCalmMode(enabled, reason = {}) {
+  state.calmMode = enabled;
+  calmToggle.checked = enabled;
+  storeState(storageKeys.calm, enabled);
+  state.current?.instance?.setCalmMode?.(enabled, reason);
+}
+
+function updateExplainPanel() {
+  const descriptor = state.current?.descriptor;
+  if (!descriptor) return;
+  if (!state.shouldExplain) {
+    explainPanel.hidden = true;
+    return;
+  }
+  explainPanel.hidden = false;
+  explainTitle.textContent = descriptor.name;
+  const explanation = descriptor.explain ?? '';
+  if (typeof explanation === 'string') {
+    explainContent.textContent = explanation;
+  } else if (Array.isArray(explanation)) {
+    explainContent.innerHTML = explanation.map((paragraph) => `<p>${paragraph}</p>`).join('');
+  } else if (typeof explanation === 'function') {
+    explainContent.innerHTML = explanation();
+  }
+}
+
+function loop(now) {
+  if (!state.isPlaying) {
+    rafHandle = requestAnimationFrame(loop);
+    return;
+  }
+  const delta = Math.min((now - state.lastFrame) / 1000, 0.1);
+  state.lastFrame = now;
+
+  const fps = state.fpsCounter.frame();
+  state.fpsTimer += delta;
+  if (state.fpsTimer > 0.25) {
+    fpsMeter.textContent = `${formatFPS(fps)} FPS`;
+    state.fpsTimer = 0;
+  }
+
+  state.current?.instance?.update?.(delta, now / 1000);
+  state.current?.instance?.render?.(ctx, state.size);
+
+  state.autoDrop?.(delta);
+
+  rafHandle = requestAnimationFrame(loop);
+}
+
+init();

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,851 @@
+export const TAU = Math.PI * 2;
+export const PHI = (1 + Math.sqrt(5)) / 2;
+export const GOLDEN_ANGLE_DEG = 137.50776405003785;
+export const GOLDEN_ANGLE_RAD = GOLDEN_ANGLE_DEG * (Math.PI / 180);
+
+/**
+ * Create a deterministic pseudo random number generator based on Mulberry32.
+ * The generator returns values in [0, 1).
+ * @param {number|string} seed
+ * @returns {() => number}
+ */
+export function createSeededRng(seed) {
+  let value = typeof seed === 'string' ? hashString(seed) : seed >>> 0;
+  if (!value) value = 0x12345678;
+  return function rng() {
+    value |= 0;
+    value = (value + 0x6d2b79f5) | 0;
+    let t = Math.imul(value ^ (value >>> 15), 1 | value);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function hashString(str) {
+  let h = 1779033703 ^ str.length;
+  for (let i = 0; i < str.length; i += 1) {
+    h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  h = Math.imul(h ^ (h >>> 16), 2246822507);
+  h = Math.imul(h ^ (h >>> 13), 3266489909);
+  return (h ^= h >>> 16) >>> 0;
+}
+
+export function randomInt(rng, min, max) {
+  return Math.floor(rng() * (max - min + 1)) + min;
+}
+
+export function randomRange(rng, min, max) {
+  return rng() * (max - min) + min;
+}
+
+export function clamp(value, min, max) {
+  return value < min ? min : value > max ? max : value;
+}
+
+export function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+export function mapRange(value, inMin, inMax, outMin, outMax) {
+  if (inMax === inMin) return outMin;
+  const t = (value - inMin) / (inMax - inMin);
+  return lerp(outMin, outMax, t);
+}
+
+export function smoothstep(t) {
+  return t * t * (3 - 2 * t);
+}
+
+export function easeOutExpo(t) {
+  return t === 1 ? 1 : 1 - Math.pow(2, -10 * t);
+}
+
+export function easeInOutQuad(t) {
+  return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+}
+
+export function mod(n, m) {
+  return ((n % m) + m) % m;
+}
+
+export function wrap(value, min, max) {
+  const range = max - min;
+  if (!range) return min;
+  let result = value - min;
+  result = mod(result, range);
+  return result + min;
+}
+
+export function wrapAngle(rad) {
+  return wrap(rad, -Math.PI, Math.PI);
+}
+
+export function degToRad(deg) {
+  return (deg * Math.PI) / 180;
+}
+
+export function radToDeg(rad) {
+  return (rad * 180) / Math.PI;
+}
+
+export function generateSeed() {
+  const timeSeed = Math.floor(Date.now() % 0xffffffff);
+  return timeSeed ^ Math.floor(Math.random() * 0xffffffff);
+}
+
+export function setCanvasSize(canvas, width, height, { maxDpr = 2, allowImageSmoothing = true } = {}) {
+  const dpr = Math.min(window.devicePixelRatio || 1, maxDpr);
+  if (canvas.width !== Math.floor(width * dpr) || canvas.height !== Math.floor(height * dpr)) {
+    canvas.width = Math.floor(width * dpr);
+    canvas.height = Math.floor(height * dpr);
+  }
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+  const ctx = canvas.getContext('2d');
+  if (ctx) {
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.imageSmoothingEnabled = allowImageSmoothing;
+  }
+  return { width, height, dpr };
+}
+
+export function downloadCanvasPNG(canvas, name = 'math-demo.png') {
+  const link = document.createElement('a');
+  link.download = name;
+  link.href = canvas.toDataURL('image/png');
+  link.click();
+}
+
+export function throttle(fn, wait) {
+  let lastCall = 0;
+  let timeout = null;
+  let lastArgs;
+  const invoke = () => {
+    lastCall = Date.now();
+    timeout = null;
+    fn.apply(null, lastArgs);
+  };
+  return (...args) => {
+    const now = Date.now();
+    lastArgs = args;
+    if (!lastCall || now - lastCall >= wait) {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+      invoke();
+    } else if (!timeout) {
+      const remaining = wait - (now - lastCall);
+      timeout = setTimeout(invoke, remaining);
+    }
+  };
+}
+
+export function debounce(fn, wait) {
+  let timeout;
+  return (...args) => {
+    if (timeout) clearTimeout(timeout);
+    timeout = setTimeout(() => fn.apply(null, args), wait);
+  };
+}
+
+export function createFPSCounter(samples = 30) {
+  const values = [];
+  let last = performance.now();
+  return {
+    frame() {
+      const now = performance.now();
+      const delta = now - last;
+      last = now;
+      const fps = 1000 / (delta || 1);
+      values.push(fps);
+      if (values.length > samples) values.shift();
+      const avg = values.reduce((a, b) => a + b, 0) / values.length;
+      return avg;
+    },
+    reset() {
+      values.length = 0;
+      last = performance.now();
+    },
+  };
+}
+
+export function prefersReducedMotion() {
+  const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+  return media.matches;
+}
+
+export function listenPrefersReducedMotion(handler) {
+  const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+  const listener = (event) => handler(event.matches);
+  if (typeof media.addEventListener === 'function') {
+    media.addEventListener('change', listener);
+  } else {
+    media.addListener(listener);
+  }
+  return () => {
+    if (typeof media.removeEventListener === 'function') {
+      media.removeEventListener('change', listener);
+    } else {
+      media.removeListener(listener);
+    }
+  };
+}
+
+export function isCoarsePointer() {
+  return window.matchMedia('(pointer: coarse)').matches;
+}
+
+export function ensureReadableHex(hex) {
+  if (!hex) return '#ffffff';
+  if (hex.startsWith('#')) return hex;
+  return `#${hex}`;
+}
+
+export const paletteLibrary = {
+  sunflower: ['#fed766', '#ffa400', '#fa7921', '#035aa6', '#231123'],
+  aurora: ['#3a0ca3', '#4361ee', '#4cc9f0', '#f72585', '#b5179e'],
+  ocean: ['#011627', '#2ec4b6', '#e71d36', '#ff9f1c', '#fdfffc'],
+  twilight: ['#0b3954', '#087e8b', '#bfd7ea', '#ff5a5f', '#c81d25'],
+  meadow: ['#233d4d', '#619b8a', '#a1c181', '#fcca46', '#fe7f2d'],
+  monochrome: ['#f0f0f0', '#bdbdbd', '#636363', '#252525', '#000000'],
+};
+
+export function getPaletteNames() {
+  return Object.keys(paletteLibrary);
+}
+
+export function pickPalette(name = 'sunflower') {
+  return paletteLibrary[name] || paletteLibrary.sunflower;
+}
+
+export function lerpColor(hexA, hexB, t) {
+  const a = hexToRgb(hexA);
+  const b = hexToRgb(hexB);
+  const r = Math.round(lerp(a.r, b.r, t));
+  const g = Math.round(lerp(a.g, b.g, t));
+  const bl = Math.round(lerp(a.b, b.b, t));
+  return `rgb(${r}, ${g}, ${bl})`;
+}
+
+export function hexToRgb(hex) {
+  const clean = ensureReadableHex(hex).replace('#', '');
+  const value = clean.length === 3
+    ? clean.split('').map((c) => parseInt(c + c, 16))
+    : [parseInt(clean.slice(0, 2), 16), parseInt(clean.slice(2, 4), 16), parseInt(clean.slice(4, 6), 16)];
+  return { r: value[0], g: value[1], b: value[2] };
+}
+
+export function toVector(polarAngle, radius = 1) {
+  return {
+    x: Math.cos(polarAngle) * radius,
+    y: Math.sin(polarAngle) * radius,
+  };
+}
+
+export function formatFPS(fps) {
+  if (!Number.isFinite(fps)) return '--';
+  if (fps < 1) return fps.toFixed(1);
+  return fps.toFixed(0);
+}
+
+export function createPointerTracker(element, callbacks) {
+  let active = false;
+  let last = null;
+
+  const onPointerDown = (event) => {
+    active = true;
+    last = { x: event.clientX, y: event.clientY };
+    element.setPointerCapture(event.pointerId);
+    callbacks.onDown?.(event, last);
+  };
+
+  const onPointerMove = (event) => {
+    if (!active) return;
+    const next = { x: event.clientX, y: event.clientY };
+    const dx = next.x - last.x;
+    const dy = next.y - last.y;
+    callbacks.onDrag?.(event, { dx, dy, x: next.x, y: next.y });
+    last = next;
+  };
+
+  const onPointerUp = (event) => {
+    if (!active) return;
+    active = false;
+    callbacks.onUp?.(event);
+    try {
+      element.releasePointerCapture(event.pointerId);
+    } catch (_) {
+      // ignore
+    }
+  };
+
+  element.addEventListener('pointerdown', onPointerDown);
+  element.addEventListener('pointermove', onPointerMove);
+  element.addEventListener('pointerup', onPointerUp);
+  element.addEventListener('pointercancel', onPointerUp);
+
+  return () => {
+    element.removeEventListener('pointerdown', onPointerDown);
+    element.removeEventListener('pointermove', onPointerMove);
+    element.removeEventListener('pointerup', onPointerUp);
+    element.removeEventListener('pointercancel', onPointerUp);
+  };
+}
+
+export function createTimer() {
+  let last = performance.now();
+  return () => {
+    const now = performance.now();
+    const delta = (now - last) / 1000;
+    last = now;
+    return delta;
+  };
+}
+
+export function withOffscreenCanvas(canvas) {
+  if (!canvas || !canvas.transferControlToOffscreen) return null;
+  try {
+    return canvas.transferControlToOffscreen();
+  } catch (error) {
+    console.warn('Failed to create OffscreenCanvas', error);
+    return null;
+  }
+}
+
+export function storeState(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.warn('Unable to persist state', error);
+  }
+}
+
+export function loadState(key, fallback) {
+  try {
+    const stored = localStorage.getItem(key);
+    return stored ? JSON.parse(stored) : fallback;
+  } catch (error) {
+    return fallback;
+  }
+}
+
+export function createScrollableParameter({ min = 0, max = 1, start = 0, step = 0.01 }) {
+  let value = clamp(start, min, max);
+  return {
+    get value() {
+      return value;
+    },
+    update(deltaY) {
+      const direction = deltaY > 0 ? 1 : -1;
+      value = clamp(value + direction * step, min, max);
+      return value;
+    },
+    set(next) {
+      value = clamp(next, min, max);
+    },
+  };
+}
+
+export function seededShuffle(rng, array) {
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
+export function average(arr) {
+  if (!arr.length) return 0;
+  return arr.reduce((acc, val) => acc + val, 0) / arr.length;
+}
+
+export function pointDistance(ax, ay, bx, by) {
+  const dx = ax - bx;
+  const dy = ay - by;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+export function polygonArea(points) {
+  let area = 0;
+  for (let i = 0; i < points.length; i += 1) {
+    const { x: x1, y: y1 } = points[i];
+    const { x: x2, y: y2 } = points[(i + 1) % points.length];
+    area += x1 * y2 - x2 * y1;
+  }
+  return area / 2;
+}
+
+export function polygonCentroid(points) {
+  let cx = 0;
+  let cy = 0;
+  let area = 0;
+  for (let i = 0; i < points.length; i += 1) {
+    const { x: x1, y: y1 } = points[i];
+    const { x: x2, y: y2 } = points[(i + 1) % points.length];
+    const cross = x1 * y2 - x2 * y1;
+    cx += (x1 + x2) * cross;
+    cy += (y1 + y2) * cross;
+    area += cross;
+  }
+  area *= 0.5;
+  if (!area) return { x: 0, y: 0 };
+  cx /= 6 * area;
+  cy /= 6 * area;
+  return { x: cx, y: cy };
+}
+
+export function computePrimeColor(k, palette) {
+  return palette[k % palette.length];
+}
+
+export function composeTransforms(transforms) {
+  return transforms.reduce(
+    (acc, matrix) => {
+      const [a1, b1, c1, d1, e1, f1] = acc;
+      const [a2, b2, c2, d2, e2, f2] = matrix;
+      return [
+        a1 * a2 + c1 * b2,
+        b1 * a2 + d1 * b2,
+        a1 * c2 + c1 * d2,
+        b1 * c2 + d1 * d2,
+        a1 * e2 + c1 * f2 + e1,
+        b1 * e2 + d1 * f2 + f1,
+      ];
+    },
+    [1, 0, 0, 1, 0, 0]
+  );
+}
+
+export function applyMatrix(ctx, matrix) {
+  ctx.setTransform(...matrix);
+}
+
+export function formatRatio(a, b) {
+  return `${a}:${b}`;
+}
+
+export function makeEventBus() {
+  const listeners = new Map();
+  return {
+    on(event, handler) {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event).add(handler);
+      return () => listeners.get(event).delete(handler);
+    },
+    emit(event, payload) {
+      const group = listeners.get(event);
+      if (!group) return;
+      group.forEach((handler) => handler(payload));
+    },
+    clear() {
+      listeners.clear();
+    },
+  };
+}
+
+export function seededNoise1D(seed, frequency = 1) {
+  const rng = createSeededRng(seed);
+  const gradients = new Map();
+  const getGradient = (x) => {
+    const key = Math.floor(x);
+    if (!gradients.has(key)) {
+      gradients.set(key, rng() * 2 - 1);
+    }
+    return gradients.get(key);
+  };
+  return (x) => {
+    const scaled = x * frequency;
+    const x0 = Math.floor(scaled);
+    const x1 = x0 + 1;
+    const t = scaled - x0;
+    const fade = t * t * t * (t * (t * 6 - 15) + 10);
+    const g0 = getGradient(x0);
+    const g1 = getGradient(x1);
+    const v0 = g0 * (scaled - x0);
+    const v1 = g1 * (scaled - x1);
+    return lerp(v0, v1, fade);
+  };
+}
+
+export function seededNoise2D(seed, frequency = 1) {
+  const rng = createSeededRng(seed);
+  const gradients = new Map();
+  const gradient = () => {
+    const angle = rng() * TAU;
+    return { x: Math.cos(angle), y: Math.sin(angle) };
+  };
+  const keyFor = (x, y) => `${x}|${y}`;
+  const getGradient = (x, y) => {
+    const key = keyFor(x, y);
+    if (!gradients.has(key)) gradients.set(key, gradient());
+    return gradients.get(key);
+  };
+  const fade = (t) => t * t * t * (t * (t * 6 - 15) + 10);
+  return (x, y) => {
+    const nx = x * frequency;
+    const ny = y * frequency;
+    const x0 = Math.floor(nx);
+    const y0 = Math.floor(ny);
+    const x1 = x0 + 1;
+    const y1 = y0 + 1;
+    const sx = nx - x0;
+    const sy = ny - y0;
+
+    const g00 = getGradient(x0, y0);
+    const g10 = getGradient(x1, y0);
+    const g01 = getGradient(x0, y1);
+    const g11 = getGradient(x1, y1);
+
+    const dot00 = g00.x * (nx - x0) + g00.y * (ny - y0);
+    const dot10 = g10.x * (nx - x1) + g10.y * (ny - y0);
+    const dot01 = g01.x * (nx - x0) + g01.y * (ny - y1);
+    const dot11 = g11.x * (nx - x1) + g11.y * (ny - y1);
+
+    const u = fade(sx);
+    const v = fade(sy);
+
+    const ix0 = lerp(dot00, dot10, u);
+    const ix1 = lerp(dot01, dot11, u);
+    return lerp(ix0, ix1, v);
+  };
+}
+
+export function computeLSystemIterations(axiom, rules, iterations) {
+  let result = axiom;
+  for (let i = 0; i < iterations; i += 1) {
+    let next = '';
+    for (let char of result) {
+      next += rules[char] || char;
+    }
+    result = next;
+  }
+  return result;
+}
+
+export function rotatePoint({ x, y }, angle, origin = { x: 0, y: 0 }) {
+  const s = Math.sin(angle);
+  const c = Math.cos(angle);
+  const translatedX = x - origin.x;
+  const translatedY = y - origin.y;
+  return {
+    x: translatedX * c - translatedY * s + origin.x,
+    y: translatedX * s + translatedY * c + origin.y,
+  };
+}
+
+export function pointToString(point) {
+  return `${point.x.toFixed(2)},${point.y.toFixed(2)}`;
+}
+
+export function panZoomMatrix({ scale = 1, offsetX = 0, offsetY = 0 }) {
+  return [scale, 0, 0, scale, offsetX, offsetY];
+}
+
+export function getAspectRatio(width, height) {
+  return width / height;
+}
+
+export function createSvgPathSampler(pathSegments, { samples = 1024 }) {
+  const points = [];
+  for (let i = 0; i < pathSegments.length; i += 1) {
+    const seg = pathSegments[i];
+    if (seg.type === 'M') {
+      points.push({ x: seg.x, y: seg.y });
+    } else if (seg.type === 'L') {
+      const prev = points[points.length - 1];
+      for (let t = 1; t <= samples; t += 1) {
+        points.push({
+          x: lerp(prev.x, seg.x, t / samples),
+          y: lerp(prev.y, seg.y, t / samples),
+        });
+      }
+    } else if (seg.type === 'C') {
+      const prev = points[points.length - 1];
+      for (let t = 0; t <= samples; t += 1) {
+        const u = t / samples;
+        const v = 1 - u;
+        const x =
+          v * v * v * prev.x +
+          3 * v * v * u * seg.cx1 +
+          3 * v * u * u * seg.cx2 +
+          u * u * u * seg.x;
+        const y =
+          v * v * v * prev.y +
+          3 * v * v * u * seg.cy1 +
+          3 * v * u * u * seg.cy2 +
+          u * u * u * seg.y;
+        points.push({ x, y });
+      }
+    }
+  }
+  return points;
+}
+
+export function normalizePathPoints(points) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const p of points) {
+    if (p.x < minX) minX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y > maxY) maxY = p.y;
+  }
+  const width = maxX - minX || 1;
+  const height = maxY - minY || 1;
+  return points.map((p) => ({
+    x: (p.x - minX) / width - 0.5,
+    y: (p.y - minY) / height - 0.5,
+  }));
+}
+
+export function lowPass(current, target, smoothing, delta) {
+  const alpha = 1 - Math.exp(-smoothing * delta);
+  return lerp(current, target, alpha);
+}
+
+export function createColorCycle(palette) {
+  let index = 0;
+  return () => {
+    const color = palette[index % palette.length];
+    index += 1;
+    return color;
+  };
+}
+
+export function drawRoundedRect(ctx, x, y, w, h, r) {
+  const radius = Math.min(r, Math.abs(w) / 2, Math.abs(h) / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.lineTo(x + w - radius, y);
+  ctx.arcTo(x + w, y, x + w, y + radius, radius);
+  ctx.lineTo(x + w, y + h - radius);
+  ctx.arcTo(x + w, y + h, x + w - radius, y + h, radius);
+  ctx.lineTo(x + radius, y + h);
+  ctx.arcTo(x, y + h, x, y + h - radius, radius);
+  ctx.lineTo(x, y + radius);
+  ctx.arcTo(x, y, x + radius, y, radius);
+  ctx.closePath();
+}
+
+export function detectMobile() {
+  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+}
+
+export function safeCall(fn, ...args) {
+  if (typeof fn === 'function') {
+    return fn(...args);
+  }
+  return undefined;
+}
+
+export function toRadians(degrees) {
+  return degrees * (Math.PI / 180);
+}
+
+export function toDegrees(radians) {
+  return radians * (180 / Math.PI);
+}
+
+export function createRollingAverage(size = 20) {
+  const samples = new Array(size).fill(0);
+  let index = 0;
+  let filled = 0;
+  return {
+    push(value) {
+      samples[index] = value;
+      index = (index + 1) % size;
+      filled = Math.min(filled + 1, size);
+    },
+    value() {
+      if (!filled) return 0;
+      const sum = samples.slice(0, filled).reduce((acc, v) => acc + v, 0);
+      return sum / filled;
+    },
+    reset() {
+      samples.fill(0);
+      index = 0;
+      filled = 0;
+    },
+  };
+}
+
+export function createDeterministicColor(index, palette) {
+  return palette[index % palette.length];
+}
+
+export function autoDropCalmMode({ fps, calmMode, onDrop, threshold = 28, duration = 3000 }) {
+  let below = 0;
+  return (deltaTime) => {
+    if (calmMode()) {
+      below = 0;
+      return;
+    }
+    const frameFPS = 1 / deltaTime;
+    if (frameFPS < threshold) {
+      below += deltaTime * 1000;
+      if (below > duration) {
+        onDrop();
+        below = 0;
+      }
+    } else {
+      below = Math.max(0, below - deltaTime * 1000);
+    }
+  };
+}
+
+export function seededAngles(count, rng) {
+  const angles = [];
+  const angleStep = TAU / count;
+  for (let i = 0; i < count; i += 1) {
+    angles.push(angleStep * i + rng() * angleStep * 0.25);
+  }
+  return angles;
+}
+
+export function createSvgPathParser(path) {
+  const commands = path.match(/[a-zA-Z][^a-zA-Z]*/g) || [];
+  const segments = [];
+  let current = { x: 0, y: 0 };
+  for (const command of commands) {
+    const type = command[0];
+    const args = command
+      .slice(1)
+      .trim()
+      .split(/[ ,]+/)
+      .filter(Boolean)
+      .map(Number);
+    if (type === 'M' || type === 'm') {
+      const isRelative = type === 'm';
+      for (let i = 0; i < args.length; i += 2) {
+        const x = isRelative ? current.x + args[i] : args[i];
+        const y = isRelative ? current.y + args[i + 1] : args[i + 1];
+        current = { x, y };
+        segments.push({ type: 'M', x, y });
+      }
+    } else if (type === 'L' || type === 'l') {
+      const isRelative = type === 'l';
+      for (let i = 0; i < args.length; i += 2) {
+        const x = isRelative ? current.x + args[i] : args[i];
+        const y = isRelative ? current.y + args[i + 1] : args[i + 1];
+        segments.push({ type: 'L', x, y });
+        current = { x, y };
+      }
+    } else if (type === 'C' || type === 'c') {
+      const isRelative = type === 'c';
+      for (let i = 0; i < args.length; i += 6) {
+        const cx1 = isRelative ? current.x + args[i] : args[i];
+        const cy1 = isRelative ? current.y + args[i + 1] : args[i + 1];
+        const cx2 = isRelative ? current.x + args[i + 2] : args[i + 2];
+        const cy2 = isRelative ? current.y + args[i + 3] : args[i + 3];
+        const x = isRelative ? current.x + args[i + 4] : args[i + 4];
+        const y = isRelative ? current.y + args[i + 5] : args[i + 5];
+        segments.push({ type: 'C', cx1, cy1, cx2, cy2, x, y });
+        current = { x, y };
+      }
+    } else if (type === 'Z' || type === 'z') {
+      segments.push({ type: 'Z' });
+    }
+  }
+  return segments;
+}
+
+export function distanceSquared(ax, ay, bx, by) {
+  const dx = ax - bx;
+  const dy = ay - by;
+  return dx * dx + dy * dy;
+}
+
+export function radialGradient(ctx, cx, cy, r, inner, outer) {
+  const gradient = ctx.createRadialGradient(cx, cy, r * 0.1, cx, cy, r);
+  gradient.addColorStop(0, inner);
+  gradient.addColorStop(1, outer);
+  return gradient;
+}
+
+export function setCanvasBackground(ctx, width, height, color = '#05060a') {
+  ctx.save();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, width, height);
+  ctx.restore();
+}
+
+export function createGradientPalette(base, rng) {
+  const palette = [];
+  const variation = rng() * 0.2 + 0.1;
+  for (let i = 0; i < base.length - 1; i += 1) {
+    const start = base[i];
+    const end = base[i + 1];
+    const steps = 4;
+    for (let j = 0; j < steps; j += 1) {
+      palette.push(lerpColor(start, end, (j + rng() * variation) / steps));
+    }
+  }
+  palette.push(base[base.length - 1]);
+  return palette;
+}
+
+export function mix(a, b, t) {
+  return a * (1 - t) + b * t;
+}
+
+export function bezierPoint(p0, p1, p2, p3, t) {
+  const u = 1 - t;
+  return (
+    u * u * u * p0 +
+    3 * u * u * t * p1 +
+    3 * u * t * t * p2 +
+    t * t * t * p3
+  );
+}
+
+export function bezierDerivative(p0, p1, p2, p3, t) {
+  const u = 1 - t;
+  return (
+    3 * u * u * (p1 - p0) +
+    6 * u * t * (p2 - p1) +
+    3 * t * t * (p3 - p2)
+  );
+}
+
+export function chooseNearestPoint(points, target) {
+  let best = null;
+  let bestDist = Infinity;
+  for (const point of points) {
+    const dx = point.x - target.x;
+    const dy = point.y - target.y;
+    const dist = dx * dx + dy * dy;
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = point;
+    }
+  }
+  return best;
+}
+
+export function createEaseOut(tail = 3) {
+  return (t) => 1 - Math.exp(-t * tail);
+}
+
+export function hyp(x, y) {
+  return Math.sqrt(x * x + y * y);
+}
+
+export function createCircularArray(length) {
+  return {
+    length,
+    get(index) {
+      return mod(index, length);
+    },
+  };
+}
+
+export function goldenSpiralPoint(a, b, theta) {
+  const r = a * Math.exp(b * theta);
+  return { x: r * Math.cos(theta), y: r * Math.sin(theta) };
+}

--- a/workers/penrose.js
+++ b/workers/penrose.js
@@ -1,0 +1,94 @@
+// workers/penrose.js
+// Triangle-based Penrose inflation producing kite (thick) and dart (thin) halves.
+const PHI = (1 + Math.sqrt(5)) / 2;
+
+self.onmessage = (event) => {
+  const { data } = event;
+  if (!data || data.type !== 'inflate') return;
+  const iterations = Math.max(0, data.iterations | 0);
+
+  let triangles = createInitialStar();
+  for (let iter = 0; iter < iterations; iter += 1) {
+    const next = [];
+    for (const tri of triangles) {
+      const children = subdivide(tri);
+      next.push(...children);
+    }
+    triangles = next;
+  }
+
+  const flattened = new Float32Array(triangles.length * 6);
+  const types = new Uint8Array(triangles.length);
+  const bounds = { minX: Infinity, maxX: -Infinity, minY: Infinity, maxY: -Infinity };
+
+  triangles.forEach((tri, index) => {
+    flattened[index * 6 + 0] = tri.a.x;
+    flattened[index * 6 + 1] = tri.a.y;
+    flattened[index * 6 + 2] = tri.b.x;
+    flattened[index * 6 + 3] = tri.b.y;
+    flattened[index * 6 + 4] = tri.c.x;
+    flattened[index * 6 + 5] = tri.c.y;
+    types[index] = tri.type === 'thick' ? 1 : 0;
+
+    bounds.minX = Math.min(bounds.minX, tri.a.x, tri.b.x, tri.c.x);
+    bounds.maxX = Math.max(bounds.maxX, tri.a.x, tri.b.x, tri.c.x);
+    bounds.minY = Math.min(bounds.minY, tri.a.y, tri.b.y, tri.c.y);
+    bounds.maxY = Math.max(bounds.maxY, tri.a.y, tri.b.y, tri.c.y);
+  });
+
+  postMessage(
+    {
+      type: 'result',
+      triangles: flattened.buffer,
+      kinds: types.buffer,
+      bounds,
+    },
+    [flattened.buffer, types.buffer]
+  );
+};
+
+function createInitialStar() {
+  const triangles = [];
+  const radiusOuter = 0.8;
+  const radiusInner = radiusOuter / PHI;
+  for (let i = 0; i < 10; i += 1) {
+    const angle = (i * Math.PI) / 5;
+    const nextAngle = angle + Math.PI / 5;
+    const a = { x: 0, y: 0 };
+    const b = {
+      x: Math.cos(angle) * (i % 2 === 0 ? radiusOuter : radiusInner),
+      y: Math.sin(angle) * (i % 2 === 0 ? radiusOuter : radiusInner),
+    };
+    const c = {
+      x: Math.cos(nextAngle) * (i % 2 === 0 ? radiusOuter : radiusInner),
+      y: Math.sin(nextAngle) * (i % 2 === 0 ? radiusOuter : radiusInner),
+    };
+    triangles.push({ a, b, c, type: i % 2 === 0 ? 'thin' : 'thick' });
+  }
+  return triangles;
+}
+
+function subdivide(triangle) {
+  const { a, b, c, type } = triangle;
+  if (type === 'thin') {
+    const q = lerp(a, b, 1 / PHI);
+    const r = lerp(a, c, 1 / PHI);
+    return [
+      { a: r, b: c, c: b, type: 'thin' },
+      { a: q, b: r, c: b, type: 'thick' },
+    ];
+  }
+  const q = lerp(c, a, 1 / PHI);
+  const r = lerp(c, b, 1 / PHI);
+  return [
+    { a: q, b: a, c: b, type: 'thick' },
+    { a: r, b: q, c: b, type: 'thin' },
+  ];
+}
+
+function lerp(p1, p2, t) {
+  return {
+    x: p1.x + (p2.x - p1.x) * t,
+    y: p1.y + (p2.y - p1.y) * t,
+  };
+}

--- a/workers/sieve.js
+++ b/workers/sieve.js
@@ -1,0 +1,17 @@
+// workers/sieve.js
+// Sieve of Eratosthenes computed off-main-thread for the Ulam spiral.
+self.onmessage = (event) => {
+  if (!event.data || event.data.type !== 'sieve') return;
+  const max = Math.max(2, Number(event.data.max) || 0);
+  const sieve = new Uint8Array(max + 1);
+  sieve.fill(1, 2);
+  const limit = Math.floor(Math.sqrt(max));
+  for (let p = 2; p <= limit; p += 1) {
+    if (sieve[p]) {
+      for (let multiple = p * p; multiple <= max; multiple += p) {
+        sieve[multiple] = 0;
+      }
+    }
+  }
+  postMessage({ type: 'sieve-result', buffer: sieve.buffer }, [sieve.buffer]);
+};

--- a/workers/voronoi.js
+++ b/workers/voronoi.js
@@ -1,0 +1,165 @@
+// workers/voronoi.js
+// Computes Voronoi cells and Lloyd relaxation steps off the main thread.
+const PHI = (1 + Math.sqrt(5)) / 2;
+
+self.onmessage = (event) => {
+  const { data } = event;
+  if (!data || data.type !== 'compute') return;
+  const points = new Float32Array(data.points);
+  const iterations = Math.max(0, data.iterations | 0);
+
+  let sites = [];
+  for (let i = 0; i < points.length; i += 2) {
+    sites.push({ x: points[i], y: points[i + 1] });
+  }
+
+  for (let iter = 0; iter < iterations; iter += 1) {
+    const { polygons } = computeVoronoi(sites);
+    const nextSites = [];
+    for (let i = 0; i < polygons.length; i += 1) {
+      const polygon = polygons[i];
+      if (!polygon || polygon.length === 0) {
+        nextSites.push(sites[i]);
+        continue;
+      }
+      const centroid = polygonCentroid(polygon);
+      nextSites.push({ x: centroid.x, y: centroid.y });
+    }
+    sites = nextSites;
+  }
+
+  const { polygons, neighbors } = computeVoronoi(sites);
+  const flattened = [];
+  const offsets = new Uint32Array(polygons.length);
+  const counts = new Uint16Array(polygons.length);
+  let offset = 0;
+  for (let i = 0; i < polygons.length; i += 1) {
+    const polygon = polygons[i] || [];
+    offsets[i] = offset;
+    counts[i] = polygon.length;
+    for (let j = 0; j < polygon.length; j += 1) {
+      const p = polygon[j];
+      flattened.push(p.x, p.y);
+    }
+    offset += polygon.length;
+  }
+  const polygonData = new Float32Array(flattened);
+
+  const sitesArray = new Float32Array(sites.length * 2);
+  for (let i = 0; i < sites.length; i += 1) {
+    sitesArray[i * 2] = sites[i].x;
+    sitesArray[i * 2 + 1] = sites[i].y;
+  }
+
+  const edgeList = [];
+  const edgeSet = new Set();
+  neighbors.forEach((set, index) => {
+    set.forEach((neighbor) => {
+      if (neighbor <= index) return;
+      const key = `${index}|${neighbor}`;
+      if (edgeSet.has(key)) return;
+      edgeSet.add(key);
+      const a = sites[index];
+      const b = sites[neighbor];
+      edgeList.push(a.x, a.y, b.x, b.y);
+    });
+  });
+  const edgesArray = new Float32Array(edgeList);
+
+  postMessage(
+    {
+      type: 'result',
+      sites: sitesArray.buffer,
+      polygons: polygonData.buffer,
+      offsets: offsets.buffer,
+      counts: counts.buffer,
+      edges: edgesArray.buffer,
+    },
+    [sitesArray.buffer, polygonData.buffer, offsets.buffer, counts.buffer, edgesArray.buffer]
+  );
+};
+
+function computeVoronoi(sites) {
+  const polygons = new Array(sites.length);
+  const neighbors = new Map();
+  for (let i = 0; i < sites.length; i += 1) {
+    let polygon = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 1 },
+      { x: 0, y: 1 },
+    ];
+    const site = sites[i];
+    for (let j = 0; j < sites.length; j += 1) {
+      if (i === j) continue;
+      const other = sites[j];
+      const clipped = clipPolygon(polygon, site, other);
+      polygon = clipped.polygon;
+      if (clipped.shared) {
+        if (!neighbors.has(i)) neighbors.set(i, new Set());
+        neighbors.get(i).add(j);
+      }
+      if (!polygon.length) break;
+    }
+    polygons[i] = polygon;
+  }
+  return { polygons, neighbors };
+}
+
+function clipPolygon(polygon, site, other) {
+  if (!polygon.length) return { polygon: [], shared: false };
+  const result = [];
+  const d = { x: other.x - site.x, y: other.y - site.y };
+  const mid = { x: (site.x + other.x) / 2, y: (site.y + other.y) / 2 };
+  let shared = false;
+  for (let i = 0; i < polygon.length; i += 1) {
+    const current = polygon[i];
+    const next = polygon[(i + 1) % polygon.length];
+    const currentDot = dot(current, d, mid);
+    const nextDot = dot(next, d, mid);
+    const currentInside = currentDot <= 0;
+    const nextInside = nextDot <= 0;
+
+    if (currentInside && nextInside) {
+      result.push(next);
+    } else if (currentInside && !nextInside) {
+      shared = true;
+      result.push(intersection(current, next, currentDot, nextDot));
+    } else if (!currentInside && nextInside) {
+      shared = true;
+      result.push(intersection(current, next, currentDot, nextDot));
+      result.push(next);
+    }
+  }
+  return { polygon: result, shared };
+}
+
+function dot(point, direction, mid) {
+  return (point.x - mid.x) * direction.x + (point.y - mid.y) * direction.y;
+}
+
+function intersection(a, b, aDot, bDot) {
+  const t = aDot / (aDot - bDot);
+  return {
+    x: a.x + (b.x - a.x) * t,
+    y: a.y + (b.y - a.y) * t,
+  };
+}
+
+function polygonCentroid(points) {
+  if (!points.length) return { x: 0.5, y: 0.5 };
+  let area = 0;
+  let x = 0;
+  let y = 0;
+  for (let i = 0; i < points.length; i += 1) {
+    const p1 = points[i];
+    const p2 = points[(i + 1) % points.length];
+    const cross = p1.x * p2.y - p2.x * p1.y;
+    area += cross;
+    x += (p1.x + p2.x) * cross;
+    y += (p1.y + p2.y) * cross;
+  }
+  area *= 0.5;
+  if (!area) return points[0];
+  return { x: x / (6 * area), y: y / (6 * area) };
+}


### PR DESCRIPTION
## Summary
- replace the landing page with a full-screen math demo gallery and floating control UI
- add modular ES module demos for phyllotaxis, modular multiplication, lissajous, Fourier epicycles, Ulam primes, Hilbert, Koch, Voronoi, Penrose, moiré, flow field, and golden ratio grid
- implement shared utilities plus workers for prime sieving, Voronoi/Lloyd relaxation, and Penrose inflation

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c8e9a8c8508330984da06b9167d2f0