### PR TITLE
Elevate console hero overlay z-index

### DIFF
--- a/src/styles/logo-3d.css
+++ b/src/styles/logo-3d.css
@@ -6,6 +6,11 @@
 
 html[data-theme="console"] #console-hero{ display:block; }
 
+#console-hero{
+  pointer-events:none;
+  z-index:64;
+}
+
 .iip-logo-3d{
   position:absolute; left:50%; top:40%;
   transform: translate(-50%,-50%);


### PR DESCRIPTION
## Summary
- add a base rule for `#console-hero` that retains `pointer-events: none`
- raise the overlay z-index so it can render above the header when active
- keep the console theme toggle behavior for displaying the overlay intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca270e28a08330a86f21e2cd2c6e96