### PR TITLE
Fix console overlay visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,8 +277,7 @@
 <body class="relative min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 text-slate-900 antialiased dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 dark:text-slate-100">
   <a class="skip-link" href="#mainContent">Skip to main content</a>
   <!-- CODEX: CONSOLE HERO OVERLAY (3D logo + particles) -->
-  <div id="console-hero" aria-hidden="true"
-       style="position:absolute; inset:0; pointer-events:none; display:none;">
+  <div id="console-hero" aria-hidden="true">
     <!-- Canvas behind the logo for particles -->
     <canvas id="console-particles" width="0" height="0"
             style="position:absolute; inset:0; width:100%; height:100%;"></canvas>

--- a/src/styles/logo-3d.css
+++ b/src/styles/logo-3d.css
@@ -7,7 +7,10 @@
 html[data-theme="console"] #console-hero{ display:block; }
 
 #console-hero{
+  position:absolute;
+  inset:0;
   pointer-events:none;
+  display:none;
   z-index:64;
 }
 


### PR DESCRIPTION
## Summary
- move the console hero overlay positioning into the stylesheet so it no longer ships with an inline display override
- keep the overlay hidden by default but allow the console theme toggle to reveal it correctly

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ca35bb967483308af520e85b73c86d